### PR TITLE
Align CELT encoder with libopus 1.6.1 for primary byte-exact oracle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ libm = { version = "0.2", optional = true, default-features = false }
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["html_reports"] }
 proptest = "1"
-
+opus = { version = "0.3", default-features = false }
 [[bench]]
 name = "opus_bench"
 harness = false

--- a/src/celt.rs
+++ b/src/celt.rs
@@ -2910,17 +2910,19 @@ impl CeltDecoder {
             lm = 0;
         }
 
-        let tell = rc.tell();
+        let mut tell = rc.tell();
         let mut silence = false;
         if tell >= total_bits {
             silence = true;
         } else if tell == 1 {
             silence = rc.decode_bit_logp(15);
         }
-
         if silence {
-            pcm[..api_frame_size * channels].fill(0.0);
-            return api_frame_size;
+            // Pretend we've read all remaining bits (libopus celt_decoder.c:1324-1328)
+            // so that every subsequent `tell+...<=total_bits` guard correctly
+            // sees no budget left and decoding proceeds with defaults.
+            tell = total_bits;
+            rc.nbits_total += tell - rc.tell();
         }
 
         let mut pf_on = false;
@@ -3126,7 +3128,6 @@ impl CeltDecoder {
         if anti_collapse_rsv > 0 {
             anti_collapse_on = rc.dec_bits(1) != 0;
         }
-
         unquant_energy_finalise(
             mode,
             start_band,
@@ -3155,30 +3156,47 @@ impl CeltDecoder {
                 self.rng,
             );
         }
-
-        // Recompute band_amp after unquant_energy_finalise, which adjusts old_band_e.
-        // (Mirrors the encoder's resynth path: log2amp is called after quant_energy_finalise.)
-        log2amp(mode, nb_ebands, band_amp, &self.old_band_e, channels);
+        if silence {
+            // libopus celt_decoder.c:1530-1534 — silence frames carry no energy;
+            // force the long-term predictor to a noise floor so the next packet
+            // decodes cleanly. Without this the decoder's `oldBandE` retains
+            // the previous frame's energies and the next decode diverges, which
+            // is the reported "一時的に破壊" (temporarily destroyed) symptom.
+            for v in self.old_band_e[..channels * nb_ebands].iter_mut() {
+                *v = -28.0;
+            }
+        }
+        // For silence the MDCT synthesis must still run so that overlap,
+        // pre-emphasis and prefilter states advance, but with zeroed
+        // frequency bins (libopus denormalise_bands(silence=1) sets
+        // bound=0/start=end=0). Filling `w_freq` with zeros and skipping
+        // denormalisation achieves the same effect without passing a
+        // dedicated `silence` flag through `denormalise_bands`.
         self.w_freq[..frame_size * channels].fill(0.0);
         let freq = &mut self.w_freq[..frame_size * channels];
-        denormalise_bands(
-            mode,
-            x,
-            freq,
-            band_amp,
-            start_band,
-            end_band,
-            channels,
-            (1 << lm) as usize,
-        );
-        // Anti-aliasing: zero MDCT bins above the output Nyquist when
-        // downsampling (libopus denormalise_bands `if(downsample!=1)
-        // bound=IMIN(bound,N/downsample)`).
-        if self.downsample > 1 {
-            let bound = frame_size / self.downsample;
-            for c in 0..channels {
-                for i in bound..frame_size {
-                    freq[c * frame_size + i] = 0.0;
+        if !silence {
+            // Recompute band_amp after unquant_energy_finalise, which adjusts old_band_e.
+            // (Mirrors the encoder's resynth path: log2amp is called after quant_energy_finalise.)
+            log2amp(mode, nb_ebands, band_amp, &self.old_band_e, channels);
+            denormalise_bands(
+                mode,
+                x,
+                freq,
+                band_amp,
+                start_band,
+                end_band,
+                channels,
+                (1 << lm) as usize,
+            );
+            // Anti-aliasing: zero MDCT bins above the output Nyquist when
+            // downsampling (libopus denormalise_bands `if(downsample!=1)
+            // bound=IMIN(bound,N/downsample)`).
+            if self.downsample > 1 {
+                let bound = frame_size / self.downsample;
+                for c in 0..channels {
+                    for i in bound..frame_size {
+                        freq[c * frame_size + i] = 0.0;
+                    }
                 }
             }
         }

--- a/src/celt.rs
+++ b/src/celt.rs
@@ -2147,6 +2147,7 @@ impl CeltEncoder {
         let threshold = 1.0 / ((1 << self.lsb_depth) as f32);
         let mut silence = sample_max <= threshold;
         let tell_initial = rc.tell();
+        let tell_initial_frac = rc.tell_frac();
         let nb_filled_bytes_initial = ((tell_initial + 4) >> 3).max(0) as usize;
         let mut nb_compressed_bytes = (total_bits / 8) as usize;
         if tell_initial == 1 {
@@ -2192,7 +2193,7 @@ impl CeltEncoder {
                 let qg = (gain1 / 0.09375 - 1.0 + 0.5).floor() as i32;
                 let qg = qg.clamp(0, 7);
                 let pi = (pitch_index + 1) as u32;
-                let octave = 31 - pi.leading_zeros();
+                let octave = 32 - pi.leading_zeros();
                 let octave = (octave as i32 - 5).max(0) as u32;
                 rc.enc_uint(octave, 6);
                 rc.enc_bits(pi - (16 << octave), 4 + octave);
@@ -2438,7 +2439,8 @@ impl CeltEncoder {
             let tot_boost = total_boost;
             let tf_calib = 0; // simplified
             let cur_tell_frac = rc.tell_frac();
-            let tell_initial_frac = (tell_initial as i32) << BITRES; // approx ec_tell_frac initial
+            // Use the exact initial tell_frac captured at entry (libopus tell0_frac),
+            // not tell_initial<<BITRES which loses the fractional part.
             let min_allowed = {
                 let a = ((cur_tell_frac + tot_boost + (1 << (BITRES + 3)) - 1) >> (BITRES + 3)) + 2;
                 if hybrid {
@@ -2495,16 +2497,17 @@ impl CeltEncoder {
                 self.vbr_count += 1;
             }
             let alpha = if self.vbr_count < 970 {
-                // celt_rcp((vbr_count+20)<<16) approx 1/(vbr_count+20) in Q15
+                // celt_rcp((vbr_count+20)<<16) in Q15 is 32768/(vbr_count+20)
                 let v = self.vbr_count + 20;
-                (65536 / v) as i32 // Q15 approx
+                (32768 / v) as i32 // Q15
             } else {
                 33 // QCONST16(0.001,15) ~33
             };
             if self.constrained_vbr {
                 self.vbr_reservoir += target - vbr_rate;
-                // drift: MULT16_32_Q15(alpha, delta - offset - drift)
-                let delta_minus = delta - self.vbr_offset - self.vbr_drift;
+                // drift: MULT16_32_Q15(alpha, delta*(1<<lm_diff) - offset - drift) (libopus 2516)
+                let delta_scaled = delta * (1 << lm_diff);
+                let delta_minus = delta_scaled - self.vbr_offset - self.vbr_drift;
                 self.vbr_drift += ((alpha as i64 * delta_minus as i64) >> 15) as i32;
                 self.vbr_offset = -self.vbr_drift;
             }

--- a/src/celt.rs
+++ b/src/celt.rs
@@ -1773,16 +1773,30 @@ fn dynalloc_analysis_simple(
             follower[i] *= 0.5;
         }
     }
+    // Band weighting before capping: C does scale-then-min(4) (celt_encoder.c 1198-1204 + 1239).
+    // Rust was min(4)-then-scale, which diverges for follower>2 in i<8 or >4 in i>=12.
+    for i in start..end {
+        if i < 8 {
+            follower[i] *= 2.0;
+        }
+        if i >= 12 {
+            follower[i] *= 0.5;
+        }
+    }
+    // effBytes>320 boost (C 1232) — trivial, kept
+    if effective_bytes > 320 {
+        let add = (1.5f32).min(1e-3 * (effective_bytes as f32 - 320.0));
+        if start < end {
+            follower[start] += add;
+        }
+    }
+    // TODO(deferred): surround_dynalloc MAX (1182-1183), importance (1184-1191),
+    // tone compensation (1206-1222), leak_boost (1226-1230) require analysis/toneishness
+    // plumbing not yet ported. Surround currently 0, importance unused for offsets.
 
     let mut tot_boost = 0i32;
     for i in start..end {
-        let mut f = follower[i].min(4.0);
-        if i < 8 {
-            f *= 2.0;
-        }
-        if i >= 12 {
-            f *= 0.5;
-        }
+        let f = follower[i].min(4.0);
 
         let width = channels as i32 * (mode.e_bands[i + 1] - mode.e_bands[i]) as i32 * (1 << lm);
         let (boost, boost_bits) = if width < 6 {

--- a/src/celt.rs
+++ b/src/celt.rs
@@ -1689,6 +1689,9 @@ fn dynalloc_analysis_simple(
     is_transient: bool,
     offsets: &mut [i32],
     cap: &[i32],
+    lsb_depth: i32,
+    vbr: bool,
+    constrained_vbr: bool,
 ) {
     offsets.fill(0);
     if effective_bytes < (30 + 5 * lm) {
@@ -1742,8 +1745,14 @@ fn dynalloc_analysis_simple(
             follower[base + end - 2] = follower[base + end - 2].max(r);
             follower[base + end - 1] = follower[base + end - 1].max(r);
         }
+        // Clamp to noise floor (float C: GCONST etc are no-ops)
+        for i in 0..end {
+            let log_n = if i < mode.log_n.len() { mode.log_n[i] as f32 } else { 0.0 };
+            let e_mean = if i < mode.e_means.len() { mode.e_means[i] } else { 0.0 };
+            let noise_floor = 0.0625 * log_n + 0.5 + (9 - lsb_depth) as f32 - e_mean + 0.0062 * ((i + 5) * (i + 5)) as f32;
+            follower[base + i] = follower[base + i].max(noise_floor);
+        }
     }
-
     if channels == 2 {
         for i in start..end {
             let l = follower[i];
@@ -1759,7 +1768,7 @@ fn dynalloc_analysis_simple(
         }
     }
 
-    if !is_transient {
+    if (!vbr || constrained_vbr) && !is_transient {
         for i in start..end {
             follower[i] *= 0.5;
         }
@@ -1787,11 +1796,13 @@ fn dynalloc_analysis_simple(
             (b, (b * 6) << BITRES)
         };
 
-        // Keep dynalloc bounded so allocator still has base bits in CBR usage.
-        let cap_bits = ((2 * effective_bytes as i32) / 3) << (BITRES + 3);
-        if tot_boost + boost_bits > cap_bits {
-            offsets[i] = ((cap_bits - tot_boost) >> BITRES).max(0);
-            break;
+        // Cap only for CBR / non-transient constrained VBR (libopus 1254-1257)
+        if (!vbr || (constrained_vbr && !is_transient)) {
+            let cap_bits = ((2 * effective_bytes as i32) / 3) << (BITRES + 3);
+            if tot_boost + boost_bits > cap_bits {
+                offsets[i] = ((cap_bits - tot_boost) >> BITRES).max(0);
+                break;
+            }
         }
 
         let quanta = (width << BITRES).min((6 << BITRES).max(width));
@@ -2381,6 +2392,9 @@ impl CeltEncoder {
             is_transient,
             offsets,
             cap,
+            self.lsb_depth,
+            self.vbr,
+            self.constrained_vbr,
         );
 
         let mut dynalloc_logp = 6i32;

--- a/src/celt.rs
+++ b/src/celt.rs
@@ -1675,6 +1675,96 @@ fn median5(v: &[f32]) -> f32 {
     x[2]
 }
 
+// Port of celt_encoder.c tone_lpc / tone_detect (float path, no FIXED_POINT shifts)
+fn tone_lpc(x: &[f32], len: usize, delay: usize, lpc: &mut [f32; 2]) -> bool {
+    // returns true on fail
+    if len <= 2 * delay {
+        return true;
+    }
+    let mut r00 = 0.0f32;
+    let mut r01 = 0.0f32;
+    let mut r11 = 0.0f32;
+    let mut r02 = 0.0f32;
+    let mut r12 = 0.0f32;
+    let mut r22 = 0.0f32;
+    for i in 0..len - 2 * delay {
+        r00 += x[i] * x[i];
+        r01 += x[i] * x[i + delay];
+        r02 += x[i] * x[i + 2 * delay];
+    }
+    let mut edges = 0.0f32;
+    for i in 0..delay {
+        edges += x[len + i - 2 * delay] * x[len + i - 2 * delay] - x[i] * x[i];
+    }
+    r11 = r00 + edges;
+    edges = 0.0;
+    for i in 0..delay {
+        edges += x[len + i - delay] * x[len + i - delay] - x[i + delay] * x[i + delay];
+    }
+    r22 = r11 + edges;
+    edges = 0.0;
+    for i in 0..delay {
+        edges += x[len + i - 2 * delay] * x[len + i - delay] - x[i] * x[i + delay];
+    }
+    r12 = r01 + edges;
+    // Reverse and sum to get backward contribution (float: simple sums)
+    let (rr00, rr01, rr11, rr02, rr12, rr22) = (r00 + r22, r01 + r12, 2.0 * r11, 2.0 * r02, r12 + r01, r00 + r22);
+    r00 = rr00;
+    r01 = rr01;
+    r11 = rr11;
+    r02 = rr02;
+    r12 = rr12;
+    r22 = rr22;
+    let den = r00 * r11 - r01 * r01;
+    if den < 0.001 * r00 * r11 {
+        return true;
+    }
+    let mut lpc1 = (r02 * r11 - r01 * r12) / den;
+    let mut lpc0 = (r00 * r12 - r02 * r01) / den;
+    // Clamp as in C (Q29 limits)
+    lpc1 = lpc1.clamp(-1.0, 1.0);
+    lpc0 = lpc0.clamp(-1.999999, 1.999999);
+    // C does HALF check for lpc0, but float clamp suffices
+    lpc[0] = lpc0;
+    lpc[1] = lpc1;
+    false
+}
+
+fn tone_detect(in_buf: &[f32], cc: usize, n: usize, fs: i32) -> (f32, f32) {
+    // in_buf is at least N samples per channel, we use N = n (frame+overlap)
+    // For CC==2, average channels; for float, no shift scaling.
+    // Use FixedVec to stay no_std heap-free.
+    let mut x: FixedVec<f32, 2048> = FixedVec::from_value(0.0, n);
+    if cc == 2 {
+        for i in 0..n {
+            x[i] = 0.5 * (in_buf[i] + in_buf[i + n]);
+        }
+    } else {
+        for i in 0..n {
+            x[i] = in_buf[i];
+        }
+    }
+    let mut delay = 1usize;
+    let mut lpc = [0.0f32; 2];
+    let mut fail = tone_lpc(&x[..n], n, delay, &mut lpc);
+    while delay <= (fs as usize / 3000) && (fail || (lpc[0] > 1.0 && lpc[1] < 0.0)) {
+        delay *= 2;
+        fail = tone_lpc(&x[..n], n, delay, &mut lpc);
+    }
+    if !fail && lpc[0] * lpc[0] + 3.999999 * lpc[1] < 0.0 {
+        let toneishness = -lpc[1];
+        // acos needs libm in no_std
+        #[cfg(feature = "std")]
+        let freq = (0.5 * lpc[0]).acos() / delay as f32;
+        #[cfg(not(feature = "std"))]
+        let freq = crate::compat::Math::acos(0.5 * lpc[0]) / delay as f32;
+        (freq, toneishness)
+    } else {
+        (-1.0, 0.0)
+    }
+}
+
+
 #[allow(clippy::too_many_arguments)]
 fn dynalloc_analysis_simple(
     mode: &CeltMode,
@@ -1694,6 +1784,8 @@ fn dynalloc_analysis_simple(
     constrained_vbr: bool,
     analysis: &AnalysisInfo,
     surround_dynalloc: &[f32],
+    tone_freq: f32,
+    toneishness: f32,
 ) {
     offsets.fill(0);
     if effective_bytes < (30 + 5 * lm) {
@@ -1794,8 +1886,34 @@ fn dynalloc_analysis_simple(
             follower[i] *= 0.5;
         }
     }
-    // C 1206-1222 tone compensation requires tone_freq/toneishness (analysis-dependent) — deferred, structure kept
-    // if toneishness > 0.98 { boost around tone_freq }
+    // C 1206-1222: Compensate for Opus' under-allocation on tones
+    if toneishness > 0.98 {
+        let freq_bin = (tone_freq * 120.0 / core::f32::consts::PI + 0.5).floor() as i32;
+        for i in start..end {
+            let lo = mode.e_bands[i] as i32;
+            let hi = mode.e_bands[i + 1] as i32;
+            if freq_bin >= lo && freq_bin <= hi {
+                follower[i] += 2.0;
+            }
+            if freq_bin >= lo - 1 && freq_bin <= hi + 1 {
+                follower[i] += 1.0;
+            }
+            if freq_bin >= lo - 2 && freq_bin <= hi + 2 {
+                follower[i] += 1.0;
+            }
+            if freq_bin >= lo - 3 && freq_bin <= hi + 3 {
+                follower[i] += 0.5;
+            }
+        }
+        if freq_bin >= mode.e_bands[end] as i32 {
+            if end >= 1 {
+                follower[end - 1] += 2.0;
+            }
+            if end >= 2 {
+                follower[end - 2] += 1.0;
+            }
+        }
+    }
     if analysis.valid {
         // C 1226-1230: leak_boost
         for i in start..end.min(19) {
@@ -1809,7 +1927,7 @@ fn dynalloc_analysis_simple(
             follower[start] += add;
         }
     }
-    // TODO(deferred): tone compensation (1206-1222) requires toneishness plumbing
+
 
     let mut tot_boost = 0i32;
     for i in start..end {
@@ -2410,6 +2528,9 @@ impl CeltEncoder {
         } else {
             None
         };
+        // Tone detection for dynalloc (C 2022) — float path
+        // Use pcm deinterleaved buffer (channel-contiguous) as in libopus in=CC*N
+        let (tone_freq, toneishness) = tone_detect(pcm, channels, frame_size, mode.fs);
         // Surround masking dynalloc (C 2112-2140) — full computation requires energy_mask/hybrid logic,
         // currently zeroed as neutral input to dynalloc's MAX step (1182). Wired for future port.
         let surround_dynalloc = [0.0f32; 21];
@@ -2431,6 +2552,8 @@ impl CeltEncoder {
             self.constrained_vbr,
             &self.analysis,
             &surround_dynalloc,
+            tone_freq,
+            toneishness,
         );
 
         let mut dynalloc_logp = 6i32;

--- a/src/celt.rs
+++ b/src/celt.rs
@@ -333,7 +333,8 @@ fn transient_analysis(
         mem0 = 0.0f32;
         for i in 0..len2 {
             let x2 = (tmp[2 * i] * tmp[2 * i] + tmp[2 * i + 1] * tmp[2 * i + 1]) / 16.0;
-            mean += x2 / 4096.0;
+            // C float build: PSHR32(x2, 12) is an identity, so mean += x2
+            mean += x2;
             mem0 = x2 + (1.0 - forward_decay) * mem0;
             tmp2[i] = forward_decay * mem0;
         }
@@ -349,19 +350,22 @@ fn transient_analysis(
         }
 
         mean = (mean * max_e * 0.5 * (len2 as f32)).sqrt();
-        let norm = (len2 as f32) / (1e-10 + mean);
+        // C (float build): norm = len2 / (EPSILON + mean)  [EPSILON = 1e-15f]
+        let norm = (len2 as f32) / (1e-15 + mean);
 
-        let mut unmask = 0.0f32;
+        // C computes the harmonic mean with INTEGER arithmetic (mask_metric and
+        // unmask are opus_int32; the 64/6 scaling is an integer division).
+        let mut unmask: i32 = 0;
         for i in (12..(len2 - 5)).step_by(4) {
-            let id = (64.0 * norm * (tmp2[i] + 1e-10)).floor() as i32;
+            let id = (64.0 * norm * (tmp2[i] + 1e-15)).floor() as i32;
             let id = id.clamp(0, 127) as usize;
-            unmask += INV_TABLE[id] as f32;
+            unmask += INV_TABLE[id] as i32;
         }
 
-        unmask = 64.0 * unmask * 4.0 / (6.0 * (len2 as f32 - 17.0));
-        if unmask > mask_metric {
+        unmask = 64 * unmask * 4 / (6 * (len2 as i32 - 17));
+        if (unmask as f32) > mask_metric {
             *tf_chan = c;
-            mask_metric = unmask;
+            mask_metric = unmask as f32;
         }
     }
 
@@ -372,7 +376,10 @@ fn transient_analysis(
         mask_metric = 0.0;
     }
 
-    *tf_estimate = (mask_metric - 150.0).clamp(0.0, 1.0);
+    // C (celt_encoder.c:460-461): tf_max = max(0, sqrt(27*mask_metric) - 42);
+    // tf_estimate = sqrt(max(0, 0.0069*min(163, tf_max) - 0.139))  [float build]
+    let tf_max = ((27.0 * mask_metric).sqrt() - 42.0).max(0.0);
+    *tf_estimate = (0.0069 * tf_max.min(163.0) - 0.139).max(0.0).sqrt();
 
     is_transient
 }
@@ -501,6 +508,7 @@ fn tf_analysis(
     lm: i32,
     tf_estimate: f32,
     tf_chan: usize,
+    importance: &[i32],
 ) -> i32 {
     debug_assert!(len <= MAX_NB_EBANDS);
     let mut metric = [0i32; MAX_NB_EBANDS];
@@ -553,80 +561,98 @@ fn tf_analysis(
     }
 
     let mut tf_select = 0;
-    let importance = [1.0f32; MAX_NB_EBANDS];
-    let mut selcost = [0.0f32; 2];
+    let mut selcost = [0i32; 2];
 
     for sel in 0..2 {
         let mut cost0 = importance[0]
-            * ((metric[0]
+            * (metric[0]
                 - 2 * TF_SELECT_TABLE[lm as usize][4 * (is_transient as usize) + 2 * sel] as i32)
-                as f32)
                 .abs();
         let mut cost1 = importance[0]
-            * ((metric[0]
+            * (metric[0]
                 - 2 * TF_SELECT_TABLE[lm as usize][4 * (is_transient as usize) + 2 * sel + 1]
-                    as i32) as f32)
+                    as i32)
                 .abs()
-            + (if is_transient { 0.0 } else { lambda as f32 });
+            + if is_transient { 0 } else { lambda };
 
         for i in 1..len {
-            let curr0 = cost0.min(cost1 + lambda as f32);
-            let curr1 = (cost0 + lambda as f32).min(cost1);
+            let curr0 = cost0.min(cost1 + lambda);
+            let curr1 = (cost0 + lambda).min(cost1);
             cost0 = curr0
                 + importance[i]
-                    * ((metric[i]
-                        - 2 * TF_SELECT_TABLE[lm as usize][4 * (is_transient as usize) + 2 * sel]
-                            as i32) as f32)
+                    * (metric[i]
+                        - 2 * TF_SELECT_TABLE[lm as usize]
+                            [4 * (is_transient as usize) + 2 * sel]
+                            as i32)
                         .abs();
             cost1 = curr1
                 + importance[i]
-                    * ((metric[i]
+                    * (metric[i]
                         - 2 * TF_SELECT_TABLE[lm as usize]
                             [4 * (is_transient as usize) + 2 * sel + 1]
-                            as i32) as f32)
+                            as i32)
                         .abs();
         }
         selcost[sel] = cost0.min(cost1);
     }
 
-    if selcost[1] < selcost[0] {
+    // C: only allow tf_select=1 for transients (celt_encoder.c:787)
+    if selcost[1] < selcost[0] && is_transient {
         tf_select = 1;
     }
 
+    // Viterbi forward pass with path storage, then backward pass to
+    // reconstruct the optimal tf_res (C celt_encoder.c:789-822).
+    let sel = tf_select as usize;
     let mut cost0 = importance[0]
-        * ((metric[0]
-            - 2 * TF_SELECT_TABLE[lm as usize][4 * (is_transient as usize) + 2 * tf_select] as i32)
-            as f32)
+        * (metric[0] - 2 * TF_SELECT_TABLE[lm as usize][4 * (is_transient as usize) + 2 * sel] as i32)
             .abs();
     let mut cost1 = importance[0]
-        * ((metric[0]
-            - 2 * TF_SELECT_TABLE[lm as usize][4 * (is_transient as usize) + 2 * tf_select + 1]
-                as i32) as f32)
+        * (metric[0]
+            - 2 * TF_SELECT_TABLE[lm as usize][4 * (is_transient as usize) + 2 * sel + 1] as i32)
             .abs()
-        + (if is_transient { 0.0 } else { lambda as f32 });
+        + if is_transient { 0 } else { lambda };
 
-    tf_res[0] = if cost0 < cost1 { 0 } else { 1 };
-
+    let mut path0 = [0i32; MAX_NB_EBANDS];
+    let mut path1 = [0i32; MAX_NB_EBANDS];
     for i in 1..len {
-        let curr0 = cost0.min(cost1 + lambda as f32);
-        let curr1 = (cost0 + lambda as f32).min(cost1);
+        let from0 = cost0;
+        let from1 = cost1 + lambda;
+        let curr0 = if from0 < from1 {
+            path0[i] = 0;
+            from0
+        } else {
+            path0[i] = 1;
+            from1
+        };
+
+        let from0 = cost0 + lambda;
+        let from1 = cost1;
+        let curr1 = if from0 < from1 {
+            path1[i] = 0;
+            from0
+        } else {
+            path1[i] = 1;
+            from1
+        };
+
         cost0 = curr0
             + importance[i]
-                * ((metric[i]
-                    - 2 * TF_SELECT_TABLE[lm as usize][4 * (is_transient as usize) + 2 * tf_select]
-                        as i32) as f32)
+                * (metric[i] - 2 * TF_SELECT_TABLE[lm as usize][4 * (is_transient as usize) + 2 * sel] as i32)
                     .abs();
         cost1 = curr1
             + importance[i]
-                * ((metric[i]
-                    - 2 * TF_SELECT_TABLE[lm as usize]
-                        [4 * (is_transient as usize) + 2 * tf_select + 1]
-                        as i32) as f32)
+                * (metric[i]
+                    - 2 * TF_SELECT_TABLE[lm as usize][4 * (is_transient as usize) + 2 * sel + 1]
+                        as i32)
                     .abs();
-        tf_res[i] = if cost0 < cost1 { 0 } else { 1 };
+    }
+    tf_res[len - 1] = if cost0 < cost1 { 0 } else { 1 };
+    for i in (0..len - 1).rev() {
+        tf_res[i] = if tf_res[i + 1] == 1 { path1[i + 1] } else { path0[i + 1] };
     }
 
-    tf_select as i32
+    tf_select
 }
 
 fn tf_encode(
@@ -1308,6 +1334,11 @@ fn run_prefilter(
 
     analysis: &AnalysisInfo,
     loss_rate: i32,
+    tf_estimate: f32,
+    nb_available_bytes: usize,
+    tone_freq: f32,
+    toneishness: f32,
+    complexity: i32,
 ) -> (bool, f32, usize) {
     let max_period = COMBFILTER_MAXPERIOD;
     let min_period = COMBFILTER_MINPERIOD;
@@ -1322,50 +1353,90 @@ fn run_prefilter(
         );
     }
 
-    let pitch_buf_len = (max_period + frame_size) >> 1;
-    {
-        let mut pre_slices: FixedVec<&[f32], 2> = FixedVec::new();
-        for c in 0..channels {
-            pre_slices.push(&pre[c * pre_size..c * pre_size + pre_size]);
+    let enabled = true;
+    let mut pitch_index = COMBFILTER_MINPERIOD;
+    let mut gain1 = 0.0f32;
+    if enabled && toneishness > 0.99 {
+        // Tone path (C 1449-1473): bypass the pitch search for pure tones.
+        let mut multiple = 1.0f32;
+        let mut tone_freq = tone_freq;
+        if tone_freq >= 3.1416 {
+            tone_freq = 3.141593 - tone_freq;
         }
-        crate::pitch::pitch_downsample(&pre_slices, pitch_buf, pitch_buf_len, channels, 2);
+        while tone_freq >= multiple * 0.39 {
+            multiple += 1.0;
+        }
+        if tone_freq > 0.006148 {
+            pitch_index = ((0.5 + 2.0 * core::f32::consts::PI * multiple / tone_freq) as usize)
+                .min(COMBFILTER_MAXPERIOD - 2);
+        } else {
+            pitch_index = COMBFILTER_MINPERIOD;
+        }
+        gain1 = 0.75;
+    } else if enabled && complexity >= 5 {
+        let pitch_buf_len = (max_period + frame_size) >> 1;
+        {
+            let mut pre_slices: FixedVec<&[f32], 2> = FixedVec::new();
+            for c in 0..channels {
+                pre_slices.push(&pre[c * pre_size..c * pre_size + pre_size]);
+            }
+            crate::pitch::pitch_downsample(&pre_slices, pitch_buf, pitch_buf_len, channels, 2);
+        }
+
+        let search_max = max_period - 3 * min_period;
+        let pitch_result = crate::pitch::pitch_search(
+            &pitch_buf[max_period >> 1..],
+            pitch_buf,
+            frame_size,
+            search_max,
+        );
+        pitch_index = (max_period - pitch_result).min(max_period - 2);
+
+        gain1 = crate::pitch::remove_doubling(
+            pitch_buf,
+            max_period,
+            min_period,
+            frame_size,
+            &mut pitch_index,
+            prefilter_period,
+            prefilter_gain,
+        );
+        if pitch_index > max_period - 2 {
+            pitch_index = max_period - 2;
+        }
+        gain1 *= 0.7;
+        // C: halve at >2% loss, halve again at >4%, zero at >8%
+        if loss_rate > 2 {
+            gain1 *= 0.5;
+        }
+        if loss_rate > 4 {
+            gain1 *= 0.5;
+        }
+        if loss_rate > 8 {
+            gain1 = 0.0;
+        }
+    } else {
+        gain1 = 0.0;
+        pitch_index = COMBFILTER_MINPERIOD;
     }
 
-    let search_max = max_period - 3 * min_period;
-    let pitch_result = crate::pitch::pitch_search(
-        &pitch_buf[max_period >> 1..],
-        pitch_buf,
-        frame_size,
-        search_max,
-    );
-    let mut pitch_index = (max_period - pitch_result).min(max_period - 2);
-
-    let gain1_raw = crate::pitch::remove_doubling(
-        pitch_buf,
-        max_period,
-        min_period,
-        frame_size,
-        &mut pitch_index,
-        prefilter_period,
-        prefilter_gain,
-    );
-    let mut gain1 = gain1_raw * 0.7;
-
-    // Apply max_pitch_ratio from analysis if available
     if analysis.valid {
         gain1 *= analysis.max_pitch_ratio;
-    }
-
-    // Apply loss_rate scaling: halve at 2%, quarter at 4%, zero at 8%
-    if loss_rate >= 8 {
-        gain1 = 0.0;
-    } else if loss_rate > 0 {
-        gain1 *= 1.0 - (loss_rate as f32) / 8.0;
     }
 
     let mut pf_threshold = 0.2f32;
     if (pitch_index as i32 - prefilter_period as i32).unsigned_abs() as usize * 10 > pitch_index {
         pf_threshold += 0.2;
+        // Completely disable the prefilter on strong transients without continuity.
+        if tf_estimate > 0.98 {
+            gain1 = 0.0;
+        }
+    }
+    if nb_available_bytes < 25 {
+        pf_threshold += 0.1;
+    }
+    if nb_available_bytes < 35 {
+        pf_threshold += 0.1;
     }
     if prefilter_gain > 0.4 {
         pf_threshold -= 0.1;
@@ -1786,9 +1857,13 @@ fn dynalloc_analysis_simple(
     surround_dynalloc: &[f32],
     tone_freq: f32,
     toneishness: f32,
+    importance: &mut [i32],
 ) {
     offsets.fill(0);
     if effective_bytes < (30 + 5 * lm) {
+        for v in importance.iter_mut() {
+            *v = 13;
+        }
         return;
     }
 
@@ -1865,11 +1940,10 @@ fn dynalloc_analysis_simple(
         // C 1182-1183: follower = max(follower, surround_dynalloc)
         follower[i] = follower[i].max(surround_dynalloc[i]);
     }
-    // C 1184-1191: importance = floor(0.5+13*exp2(min(follower,4))) — kept for fidelity, not used for offsets
-    let mut _importance_tmp = [13i32; 21];
+    // C 1184-1191: importance = floor(0.5+13*exp2(min(follower,4)))
     for i in start..end {
         let v = follower[i].min(4.0);
-        _importance_tmp[i] = (0.5 + 13.0 * (2.0f32).powf(v)).floor() as i32;
+        importance[i] = (0.5 + 13.0 * (2.0f32).powf(v)).floor() as i32;
     }
     if (!vbr || constrained_vbr) && !is_transient {
         for i in start..end {
@@ -2203,6 +2277,10 @@ impl CeltEncoder {
  let pf_enabled =
  start_band == 0 && self.complexity >= 5 && analysis_toneishness < 0.99 && channels == 1;
         let (pf_on, gain1, pitch_index) = if pf_enabled {
+            let tell = rc.tell();
+            let nb_filled = ((tell + 4) >> 3).max(0) as usize;
+            let total = explicit_total_bits.unwrap_or_else(|| (rc.buf.len() * 8) as i32);
+            let nb_available = ((total / 8) as usize).saturating_sub(nb_filled);
             run_prefilter(
                 in_buf,
                 &mut self.prefilter_mem,
@@ -2220,6 +2298,11 @@ impl CeltEncoder {
                 &mut self.w_prefilter_after,
                 &self.analysis,
                 self.loss_rate,
+                tf_estimate,
+                nb_available,
+                tone_freq,
+                toneishness,
+                self.complexity,
             )
         } else {
             (false, 0.0f32, COMBFILTER_MINPERIOD)
@@ -2274,6 +2357,8 @@ impl CeltEncoder {
         }
         let threshold = 1.0 / ((1 << self.lsb_depth) as f32);
         let mut silence = sample_max <= threshold;
+        if frame_size == 960 && channels == 2 {
+        }
         let tell_initial = rc.tell();
         let tell_initial_frac = rc.tell_frac();
         let nb_filled_bytes_initial = ((tell_initial + 4) >> 3).max(0) as usize;
@@ -2423,6 +2508,7 @@ impl CeltEncoder {
                 .iter()
                 .all(|&e| e <= -27.0)
         };
+        let _ = intra_ener; // C st->force_intra is used instead (CTL flag, 0 by default)
         quant_coarse_energy_advanced(
             mode,
             start_band,
@@ -2436,7 +2522,7 @@ impl CeltEncoder {
             channels,
             lm,
             (total_bits / 8) as usize,
-            is_transient || intra_ener,
+            false, // force_intra: C st->force_intra (CTL flag, 0 by default)
             &mut self.delayed_intra,
             self.complexity >= 4,
             0,
@@ -2446,6 +2532,51 @@ impl CeltEncoder {
         let tf_res = &mut self.w_tf_res[..nb_ebands];
         let effective_bytes = ((total_bits / 8) as usize).max(1);
         let lambda = 80.max(20480 / effective_bytes + 2) as i32;
+
+        // C runs dynalloc_analysis before tf_analysis: it produces `importance`
+        // (used by the tf Viterbi) and `offsets` (encoded later, after spread).
+        self.w_cap[..nb_ebands].fill(0);
+        let cap = &mut self.w_cap[..nb_ebands];
+        for (i, cap_i) in cap.iter_mut().enumerate() {
+            let n = (mode.e_bands[i + 1] - mode.e_bands[i]) << lm;
+            *cap_i = ((mode.cache.caps[nb_ebands * (2 * lm + channels - 1) + i] as i32 + 64)
+                * channels as i32
+                * n as i32)
+                >> 2;
+        }
+
+        self.w_offsets[..nb_ebands].fill(0);
+        let offsets = &mut self.w_offsets[..nb_ebands];
+
+        let band_log_e2_opt = if second_mdct {
+            Some(&self.w_band_log_e2[..nb_ebands * channels] as &[f32])
+        } else {
+            None
+        };
+        let surround_dynalloc = [0.0f32; 21];
+        let mut importance = [13i32; MAX_NB_EBANDS];
+        dynalloc_analysis_simple(
+            mode,
+            band_log_e,
+            band_log_e2_opt,
+            &self.old_band_e,
+            start_band,
+            nb_ebands,
+            channels,
+            lm,
+            effective_bytes,
+            is_transient,
+            offsets,
+            cap,
+            self.lsb_depth,
+            self.vbr,
+            self.constrained_vbr,
+            &self.analysis,
+            &surround_dynalloc,
+            tone_freq,
+            toneishness,
+            &mut importance,
+        );
 
         let tf_select = if self.complexity >= 2 && effective_bytes >= 15 * channels {
             tf_analysis(
@@ -2459,6 +2590,7 @@ impl CeltEncoder {
                 lm as i32,
                 tf_estimate,
                 tf_chan,
+                &importance,
             )
         } else {
             0
@@ -2520,51 +2652,6 @@ impl CeltEncoder {
         } else {
             self.spread_decision = SPREAD_NORMAL;
         }
-
-        self.w_cap[..nb_ebands].fill(0);
-        let cap = &mut self.w_cap[..nb_ebands];
-        for (i, cap_i) in cap.iter_mut().enumerate() {
-            let n = (mode.e_bands[i + 1] - mode.e_bands[i]) << lm;
-            *cap_i = ((mode.cache.caps[nb_ebands * (2 * lm + channels - 1) + i] as i32 + 64)
-                * channels as i32
-                * n as i32)
-                >> 2;
-        }
-
-        self.w_offsets[..nb_ebands].fill(0);
-        let offsets = &mut self.w_offsets[..nb_ebands];
-
-        let band_log_e2_opt = if second_mdct {
-            Some(&self.w_band_log_e2[..nb_ebands * channels] as &[f32])
-        } else {
-            None
-        };
- // Tone detection already computed earlier (C 2022) using in_buf with N+overlap and clamped with tf_estimate
- // Reuse tone_freq/toneishness from above; do not recompute with pcm/N
-        // Surround masking dynalloc (C 2112-2140) — full computation requires energy_mask/hybrid logic,
-        // currently zeroed as neutral input to dynalloc's MAX step (1182). Wired for future port.
-        let surround_dynalloc = [0.0f32; 21];
-        dynalloc_analysis_simple(
-            mode,
-            band_log_e,
-            band_log_e2_opt,
-            &self.old_band_e,
-            start_band,
-            nb_ebands,
-            channels,
-            lm,
-            effective_bytes,
-            is_transient,
-            offsets,
-            cap,
-            self.lsb_depth,
-            self.vbr,
-            self.constrained_vbr,
-            &self.analysis,
-            &surround_dynalloc,
-            tone_freq,
-            toneishness,
-        );
 
         let mut dynalloc_logp = 6i32;
         let total_bits_bitres = total_bits << BITRES;
@@ -2734,6 +2821,20 @@ impl CeltEncoder {
         let ebits = &mut self.w_ebits[..ebands_stereo];
         let mut balance = 0;
 
+        // C: bits = packet_bits - tell - 1; then subtract anti_collapse_rsv
+        // (celt_encoder.c:2614-2618) BEFORE the allocation.
+        let mut alloc_bits = (total_bits << BITRES) - rc.tell_frac() - 1;
+        let anti_collapse_rsv = if is_transient && lm >= 2 {
+            if alloc_bits >= ((lm as i32 + 2) << BITRES) {
+                1i32 << BITRES
+            } else {
+                0
+            }
+        } else {
+            0
+        };
+        alloc_bits -= anti_collapse_rsv;
+
         self.last_coded_bands = clt_compute_allocation(
             mode,
             start_band,
@@ -2743,7 +2844,7 @@ impl CeltEncoder {
             alloc_trim,
             &mut intensity,
             &mut dual_stereo_val,
-            (total_bits << BITRES) - rc.tell_frac() - 1,
+            alloc_bits,
             &mut balance,
             pulses,
             ebits,
@@ -2771,17 +2872,6 @@ impl CeltEncoder {
         let collapse_masks = &mut self.w_collapse_masks[..nb_ebands * channels];
         let (x_split, y_split) = x.split_at_mut(frame_size);
         let y_opt = if channels == 2 { Some(y_split) } else { None };
-
-        let anti_collapse_rsv = if is_transient && lm >= 2 {
-            let remaining = (total_bits << BITRES) - rc.tell_frac() - 1;
-            if remaining >= ((lm as i32 + 2) << BITRES) {
-                1i32 << BITRES
-            } else {
-                0
-            }
-        } else {
-            0
-        };
 
         let mut dual_stereo = dual_stereo_val != 0;
 

--- a/src/celt.rs
+++ b/src/celt.rs
@@ -1535,8 +1535,10 @@ pub struct CeltEncoder {
     w_in_buf: FixedVec<f32, CELT_BUFSTRIDE>,
     w_freq: FixedVec<f32, CELT_W_FREQ>,
     w_band_e: FixedVec<f32, CELT_NB_X_CH>,
+    w_band_e2: FixedVec<f32, CELT_NB_X_CH>,
     w_x: FixedVec<f32, CELT_W_X_ENC>,
     w_band_log_e: FixedVec<f32, CELT_NB_X_CH>,
+    w_band_log_e2: FixedVec<f32, CELT_NB_X_CH>,
     w_error: FixedVec<f32, CELT_NB_X_CH>,
     w_tf_res: FixedVec<i32, CELT_NB_EBANDS>,
     w_cap: FixedVec<i32, CELT_NB_EBANDS>,
@@ -1677,6 +1679,7 @@ fn median5(v: &[f32]) -> f32 {
 fn dynalloc_analysis_simple(
     mode: &CeltMode,
     band_log_e: &[f32],
+    band_log_e2: Option<&[f32]>,
     old_band_e: &[f32],
     start: usize,
     end: usize,
@@ -1694,12 +1697,12 @@ fn dynalloc_analysis_simple(
 
     let nb = mode.nb_ebands;
     let mut follower: FixedVec<f32, CELT_NB_X_CH> = FixedVec::from_value(0.0f32, nb * channels);
-
     for c in 0..channels {
         let base = c * nb;
+        let src = if let Some(b2) = band_log_e2 { b2 } else { band_log_e };
         let mut band_log_e3: FixedVec<f32, CELT_NB_EBANDS> = FixedVec::from_value(0.0f32, end);
         for i in 0..end {
-            let mut e = band_log_e[base + i];
+            let mut e = src[base + i];
             if lm == 0 && i < 8 {
                 e = e.max(old_band_e[base + i]);
             }
@@ -1850,9 +1853,11 @@ impl CeltEncoder {
             w_in_buf: FixedVec::from_value(0.0, bufstride_x_ch),
             w_freq: FixedVec::from_value(0.0, frame_x_ch + 4),
             w_band_e: FixedVec::from_value(0.0, nb_x_ch),
+            w_band_e2: FixedVec::from_value(0.0, nb_x_ch),
 
             w_x: FixedVec::from_value(0.0, frame_x_ch + STRIDE_ACCESS_PAD),
             w_band_log_e: FixedVec::from_value(0.0, nb_x_ch),
+            w_band_log_e2: FixedVec::from_value(0.0, nb_x_ch),
             w_error: FixedVec::from_value(0.0, nb_x_ch),
             w_tf_res: FixedVec::from_value(0, nb_ebands),
             w_cap: FixedVec::from_value(0, nb_ebands),
@@ -2060,9 +2065,9 @@ impl CeltEncoder {
             self.syn_mem[channel_offset + syn_mem_size - overlap..channel_offset + syn_mem_size]
                 .copy_from_slice(&in_buf[in_buf_offset + frame_size..in_buf_offset + buf_stride]);
         }
-
         let freq = &mut self.w_freq[..frame_size * channels];
-        let (shift, b) = if is_transient {
+        // TEMP: force long for transient to avoid huge (dynalloc still simple) - proper fix is full dynalloc
+        let (shift, b) = if false && is_transient {
             (mode.max_lm, 1 << lm)
         } else {
             (mode.max_lm - lm, 1)
@@ -2209,7 +2214,30 @@ impl CeltEncoder {
                 short_blocks = true;
             }
         }
-
+        let second_mdct = short_blocks && self.complexity >= 8;
+        if second_mdct {
+            for c in 0..channels {
+                let c_buf = c * buf_stride;
+                let c_freq = c * frame_size;
+                mode.mdct.forward(
+                    &in_buf[c_buf..],
+                    &mut freq[c_freq..],
+                    mode.window,
+                    overlap,
+                    mode.max_lm - lm,
+                    1,
+                );
+            }
+            let band_e2 = &mut self.w_band_e2[..nb_ebands * channels];
+            compute_band_energies(mode, freq, band_e2, nb_ebands, channels, lm);
+            let band_log_e2 = &mut self.w_band_log_e2[..nb_ebands * channels];
+            crate::bands::amp2log2(mode, 0, nb_ebands, band_e2, band_log_e2, channels);
+            for c in 0..channels {
+                for i in 0..nb_ebands {
+                    band_log_e2[c * nb_ebands + i] += lm as f32 * 0.5;
+                }
+            }
+        }
         if short_blocks {
             let b = 1 << lm;
             let n = frame_size / b;
@@ -2357,9 +2385,15 @@ impl CeltEncoder {
         self.w_offsets[..nb_ebands].fill(0);
         let offsets = &mut self.w_offsets[..nb_ebands];
 
+        let band_log_e2_opt = if second_mdct {
+            Some(&self.w_band_log_e2[..nb_ebands * channels] as &[f32])
+        } else {
+            None
+        };
         dynalloc_analysis_simple(
             mode,
             band_log_e,
+            band_log_e2_opt,
             &self.old_band_e,
             start_band,
             nb_ebands,

--- a/src/celt.rs
+++ b/src/celt.rs
@@ -2066,58 +2066,10 @@ impl CeltEncoder {
                 .copy_from_slice(&in_buf[in_buf_offset + frame_size..in_buf_offset + buf_stride]);
         }
         let freq = &mut self.w_freq[..frame_size * channels];
-        // TEMP: force long for transient to avoid huge (dynalloc still simple) - proper fix is full dynalloc
-        let (shift, b) = if false && is_transient {
-            (mode.max_lm, 1 << lm)
-        } else {
-            (mode.max_lm - lm, 1)
-        };
-        let n = frame_size / b;
-
-        for c in 0..channels {
-            let c_buf_offset = c * buf_stride;
-
-            if c == 0 && b == 1 && channels == 1 {
-                let mut max_val = 0.0f32;
-                let check_len = (frame_size + overlap).min(buf_stride);
-                for j in 0..check_len {
-                    max_val = max_val.max(in_buf[c_buf_offset + j].abs());
-                }
-            }
-
-            for i in 0..b {
-                mode.mdct.forward(
-                    &in_buf[c_buf_offset + i * n..],
-                    &mut freq[c * frame_size + i..],
-                    mode.window,
-                    overlap,
-                    shift,
-                    b,
-                );
-            }
-        }
-
         let band_e = &mut self.w_band_e[..nb_ebands * channels];
-        compute_band_energies(mode, freq, band_e, nb_ebands, channels, lm);
-
+        let band_log_e = &mut self.w_band_log_e[..nb_ebands * channels];
         let x_pad_end = (frame_size * channels + STRIDE_ACCESS_PAD).min(self.w_x.len());
         let x = &mut self.w_x[..x_pad_end];
-        normalise_bands(
-            mode,
-            freq,
-            x,
-            band_e,
-            nb_ebands,
-            channels,
-            (1 << lm) as usize,
-        );
-
-        if channels == 1 {
-            let _ = freq[0];
-        }
-
-        let band_log_e = &mut self.w_band_log_e[..nb_ebands * channels];
-        crate::bands::amp2log2(mode, start_band, nb_ebands, band_e, band_log_e, channels);
 
         let mut total_bits = explicit_total_bits.unwrap_or_else(|| (rc.buf.len() * 8) as i32);
         self.w_error[..nb_ebands * channels].fill(0.0);
@@ -2265,6 +2217,32 @@ impl CeltEncoder {
                 channels,
                 (1 << lm) as usize,
             );
+            crate::bands::amp2log2(mode, start_band, nb_ebands, band_e, band_log_e, channels);
+        } else {
+            // Long MDCT (non-transient)
+            for c in 0..channels {
+                let c_buf = c * buf_stride;
+                let c_freq = c * frame_size;
+                mode.mdct.forward(
+                    &in_buf[c_buf..],
+                    &mut freq[c_freq..],
+                    mode.window,
+                    overlap,
+                    mode.max_lm - lm,
+                    1,
+                );
+            }
+            compute_band_energies(mode, freq, band_e, nb_ebands, channels, lm);
+            normalise_bands(
+                mode,
+                freq,
+                x,
+                band_e,
+                nb_ebands,
+                channels,
+                (1 << lm) as usize,
+            );
+            crate::bands::amp2log2(mode, start_band, nb_ebands, band_e, band_log_e, channels);
         }
 
         let intra_ener = if self.complexity >= 4 {

--- a/src/celt.rs
+++ b/src/celt.rs
@@ -2159,38 +2159,49 @@ impl CeltEncoder {
             );
         }
 
-        let mut tf_estimate = 0.0f32;
-        let mut tf_chan = 0;
-        let mut weak_transient = false;
+ // Tone detection (C 2022): use channel-contiguous in_buf with N+overlap, float path
+ let mut tone_freq = -1.0f32;
+ let mut toneishness = 0.0f32;
+ {
+ let (f, t) = tone_detect(&*in_buf, channels, buf_stride, mode.fs);
+ tone_freq = f;
+ toneishness = t;
+ }
+ let mut tf_estimate = 0.0f32;
+ let mut tf_chan = 0;
+ let mut weak_transient = false;
 
-        let is_transient = if self.complexity >= 1 {
-            transient_analysis(
-                in_buf,
-                buf_stride,
-                channels,
-                &mut tf_estimate,
-                &mut tf_chan,
-                false,
-                &mut weak_transient,
-                0.0,
-                0.0,
-                &mut self.w_transient_tmp,
-                &mut self.w_transient_tmp2,
-            )
-        } else {
-            false
-        };
+ let is_transient = if self.complexity >= 1 {
+ transient_analysis(
+ in_buf,
+ buf_stride,
+ channels,
+ &mut tf_estimate,
+ &mut tf_chan,
+ false,
+ &mut weak_transient,
+ tone_freq,
+ toneishness,
+ &mut self.w_transient_tmp,
+ &mut self.w_transient_tmp2,
+ )
+ } else {
+ false
+ };
+ // Clamp toneishness as in C 2034: toneishness = min(toneishness, 1 - tf_estimate)
+ // For float, tf_estimate is log-domain; clamp to [0,1]
+ toneishness = toneishness.min((1.0 - tf_estimate).clamp(0.0, 1.0));
 
-        // Check for pure tone: if tonality is very high, bypass pitch search
-        let toneishness = if self.analysis.valid {
-            self.analysis.tonality
-        } else {
-            0.0
-        };
-        let _tone_freq = 0.0f32; // Would be set from analysis if available
-
-        let pf_enabled =
-            start_band == 0 && self.complexity >= 5 && toneishness < 0.99 && channels == 1;
+ // Check for pure tone: if tonality is very high, bypass pitch search
+ // Keep original analysis.tonality check for prefilter gating, but dynalloc uses tone_detect result
+ let analysis_toneishness = if self.analysis.valid {
+ self.analysis.tonality
+ } else {
+ 0.0
+ };
+ // analysis_toneishness kept for prefilter gating; tone_freq/toneishness from tone_detect used for dynalloc
+ let pf_enabled =
+ start_band == 0 && self.complexity >= 5 && analysis_toneishness < 0.99 && channels == 1;
         let (pf_on, gain1, pitch_index) = if pf_enabled {
             run_prefilter(
                 in_buf,
@@ -2528,9 +2539,8 @@ impl CeltEncoder {
         } else {
             None
         };
-        // Tone detection for dynalloc (C 2022) — float path
-        // Use pcm deinterleaved buffer (channel-contiguous) as in libopus in=CC*N
-        let (tone_freq, toneishness) = tone_detect(pcm, channels, frame_size, mode.fs);
+ // Tone detection already computed earlier (C 2022) using in_buf with N+overlap and clamped with tf_estimate
+ // Reuse tone_freq/toneishness from above; do not recompute with pcm/N
         // Surround masking dynalloc (C 2112-2140) — full computation requires energy_mask/hybrid logic,
         // currently zeroed as neutral input to dynalloc's MAX step (1182). Wired for future port.
         let surround_dynalloc = [0.0f32; 21];

--- a/src/celt.rs
+++ b/src/celt.rs
@@ -1692,6 +1692,8 @@ fn dynalloc_analysis_simple(
     lsb_depth: i32,
     vbr: bool,
     constrained_vbr: bool,
+    analysis: &AnalysisInfo,
+    surround_dynalloc: &[f32],
 ) {
     offsets.fill(0);
     if effective_bytes < (30 + 5 * lm) {
@@ -1767,7 +1769,16 @@ fn dynalloc_analysis_simple(
             follower[i] = (band_log_e[i] - follower[i]).max(0.0);
         }
     }
-
+    for i in start..end {
+        // C 1182-1183: follower = max(follower, surround_dynalloc)
+        follower[i] = follower[i].max(surround_dynalloc[i]);
+    }
+    // C 1184-1191: importance = floor(0.5+13*exp2(min(follower,4))) — kept for fidelity, not used for offsets
+    let mut _importance_tmp = [13i32; 21];
+    for i in start..end {
+        let v = follower[i].min(4.0);
+        _importance_tmp[i] = (0.5 + 13.0 * (2.0f32).powf(v)).floor() as i32;
+    }
     if (!vbr || constrained_vbr) && !is_transient {
         for i in start..end {
             follower[i] *= 0.5;
@@ -1783,6 +1794,14 @@ fn dynalloc_analysis_simple(
             follower[i] *= 0.5;
         }
     }
+    // C 1206-1222 tone compensation requires tone_freq/toneishness (analysis-dependent) — deferred, structure kept
+    // if toneishness > 0.98 { boost around tone_freq }
+    if analysis.valid {
+        // C 1226-1230: leak_boost
+        for i in start..end.min(19) {
+            follower[i] += (1.0 / 64.0) * analysis.leak_boost[i] as f32;
+        }
+    }
     // effBytes>320 boost (C 1232) — trivial, kept
     if effective_bytes > 320 {
         let add = (1.5f32).min(1e-3 * (effective_bytes as f32 - 320.0));
@@ -1790,9 +1809,7 @@ fn dynalloc_analysis_simple(
             follower[start] += add;
         }
     }
-    // TODO(deferred): surround_dynalloc MAX (1182-1183), importance (1184-1191),
-    // tone compensation (1206-1222), leak_boost (1226-1230) require analysis/toneishness
-    // plumbing not yet ported. Surround currently 0, importance unused for offsets.
+    // TODO(deferred): tone compensation (1206-1222) requires toneishness plumbing
 
     let mut tot_boost = 0i32;
     for i in start..end {
@@ -2393,6 +2410,9 @@ impl CeltEncoder {
         } else {
             None
         };
+        // Surround masking dynalloc (C 2112-2140) — full computation requires energy_mask/hybrid logic,
+        // currently zeroed as neutral input to dynalloc's MAX step (1182). Wired for future port.
+        let surround_dynalloc = [0.0f32; 21];
         dynalloc_analysis_simple(
             mode,
             band_log_e,
@@ -2409,6 +2429,8 @@ impl CeltEncoder {
             self.lsb_depth,
             self.vbr,
             self.constrained_vbr,
+            &self.analysis,
+            &surround_dynalloc,
         );
 
         let mut dynalloc_logp = 6i32;

--- a/src/hp_cutoff.rs
+++ b/src/hp_cutoff.rs
@@ -54,3 +54,124 @@ pub fn hp_cutoff(
         hp_mem[3] = s[3];
     }
 }
+
+/// Direct-form-II-transposed second-order ARMA filter with **float** in/out,
+/// mirroring the float build of C `silk_biquad_res()` (opus_encoder.c). Used by
+/// the float `hp_cutoff_float` path so CELT sees the exact same pre-emphasis
+/// samples as libopus 1.6.
+///
+/// `B_Q28`/`A_Q28` are Q28 coefficients; the state `S` is 2 elements per
+/// channel (stride pass). Output is written with the same `stride` as the input.
+fn silk_biquad_res_float(
+    input: &[f32],
+    b_q28: &[i32; 3],
+    a_q28: &[i32; 2],
+    s: &mut [f32; 2],
+    output: &mut [f32],
+    len: usize,
+    stride: usize,
+) {
+    let inv = 1.0f32 / ((1i32 << 28) as f32);
+    let a0 = a_q28[0] as f32 * inv;
+    let a1 = a_q28[1] as f32 * inv;
+    let b0 = b_q28[0] as f32 * inv;
+    let b1 = b_q28[1] as f32 * inv;
+    let b2 = b_q28[2] as f32 * inv;
+
+    for k in 0..len {
+        let inval = input[k * stride];
+        let vout = s[0] + b0 * inval;
+        s[0] = s[1] - vout * a0 + b1 * inval;
+        s[1] = -vout * a1 + b2 * inval + 1e-30;
+        output[k * stride] = vout;
+    }
+}
+
+/// Floating-point high-pass `hp_cutoff` (C `hp_cutoff()` float path,
+/// opus_encoder.c:441). Writes float output; state is 4 floats.
+pub fn hp_cutoff_float(
+    input: &[f32],
+    cutoff_hz: i32,
+    output: &mut [f32],
+    hp_mem: &mut [f32; 4],
+    len: usize,
+    channels: usize,
+    fs: i32,
+) {
+    let fc_q19 = silk_div32_16(silk_smulbb(SILK_FIX_CONST_19, cutoff_hz), fs / 1000);
+
+    let r_q28 = (1i32 << 28) - silk_mul(471, fc_q19);
+
+    let b_q28 = [r_q28, -silk_lshift(r_q28, 1), r_q28];
+
+    let r_q22 = silk_rshift(r_q28, 6);
+    let a_q28 = [
+        silk_smulww(r_q22, silk_smulww(fc_q19, fc_q19) - (2i32 << 22)),
+        silk_smulww(r_q22, r_q22),
+    ];
+
+    if channels == 1 {
+        let mut s = [hp_mem[0], hp_mem[1]];
+        silk_biquad_res_float(input, &b_q28, &a_q28, &mut s, output, len, 1);
+        hp_mem[0] = s[0];
+        hp_mem[1] = s[1];
+    } else {
+        let mut s0 = [hp_mem[0], hp_mem[1]];
+        silk_biquad_res_float(input, &b_q28, &a_q28, &mut s0, output, len, channels);
+        hp_mem[0] = s0[0];
+        hp_mem[1] = s0[1];
+        let mut s1 = [hp_mem[2], hp_mem[3]];
+        silk_biquad_res_float(
+            &input[1..],
+            &b_q28,
+            &a_q28,
+            &mut s1,
+            &mut output[1..],
+            len,
+            channels,
+        );
+        hp_mem[2] = s1[0];
+        hp_mem[3] = s1[1];
+    }
+}
+
+/// DC-reject first-order high-pass filter (C `dc_reject()` float path,
+/// opus_encoder.c:507). `VERY_SMALL` matches `arch.h` float builds (1e-30f).
+/// Used for the CELT/hybrid input when the application is not VOIP.
+pub fn dc_reject_float(
+    input: &[f32],
+    cutoff_hz: i32,
+    output: &mut [f32],
+    hp_mem: &mut [f32; 4],
+    len: usize,
+    channels: usize,
+    fs: i32,
+) {
+    let coef = 6.3f32 * cutoff_hz as f32 / fs as f32;
+    let coef2 = 1.0 - coef;
+    if channels == 2 {
+        let mut m0 = hp_mem[0];
+        let mut m2 = hp_mem[2];
+        for i in 0..len {
+            let x0 = input[2 * i];
+            let x1 = input[2 * i + 1];
+            let out0 = x0 - m0;
+            let out1 = x1 - m2;
+            m0 = coef * x0 + 1e-30 + coef2 * m0;
+            m2 = coef * x1 + 1e-30 + coef2 * m2;
+            output[2 * i] = out0;
+            output[2 * i + 1] = out1;
+        }
+        hp_mem[0] = m0;
+        hp_mem[2] = m2;
+    } else {
+        let mut m0 = hp_mem[0];
+        for i in 0..len {
+            let x = input[i];
+            let y = x - m0;
+            m0 = coef * x + 1e-30 + coef2 * m0;
+            output[i] = y;
+        }
+        hp_mem[0] = m0;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub mod silk;
 pub use silk::{SilkResampler, SilkResamplerDown1_3, SilkResamplerDown1_6};
 
 pub use celt::{CeltDecoder, CeltEncoder};
-use hp_cutoff::hp_cutoff;
+use hp_cutoff::{dc_reject_float, hp_cutoff, hp_cutoff_float};
 use range_coder::RangeCoder;
 use silk::control_codec::silk_control_encoder;
 use silk::enc_api::silk_encode;
@@ -57,6 +57,12 @@ const OPUS_PCM_TAIL: usize = 240 * OPUS_MAX_CHANNELS;
 const OPUS_MAX_PACKET_FRAMES: usize = 48;
 /// RFC 6716 §3.1: a single Opus packet carries at most 1276 bytes of data.
 const OPUS_MAX_PACKET_BYTES: usize = 1276;
+/// C `OpusEncoder.delay_buffer[MAX_ENCODER_BUFFER*2]` (480 samples * 2 ch).
+/// Holds the delay-compensation ring feeding the CELT encoder.
+const OPUS_DELAY_BUF: usize = 480 * OPUS_MAX_CHANNELS;
+/// CELT/hybrid input staging cap: `(delay_compensation + frame)*channels`.
+/// Worst case 60 ms stereo @ 48 kHz: (192 + 2880) * 2 = 6144.
+const OPUS_PCM_BUF: usize = (192 + OPUS_MAX_SUBFRAME) * OPUS_MAX_CHANNELS;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Application {
@@ -129,6 +135,27 @@ pub struct OpusEncoder {
     buf_celt_input: FixedVec<f32, OPUS_MAX_FRAME>,
     #[cfg(feature = "heap")]
     buf_celt_input: Box<FixedVec<f32, OPUS_MAX_FRAME>>,
+    /// C `delay_buffer[MAX_ENCODER_BUFFER*2]`: delay-compensation ring feeding
+    /// the CELT encoder (see `encoder_buffer` / `delay_compensation`).
+    #[cfg(not(feature = "heap"))]
+    delay_buffer: FixedVec<f32, OPUS_DELAY_BUF>,
+    #[cfg(feature = "heap")]
+    delay_buffer: Box<FixedVec<f32, OPUS_DELAY_BUF>>,
+    /// Interleaved `pcm_buf` staging: `delay prefix + filtered frame` exactly
+    /// like C `opus_encode_frame_native()` builds it before CELT encoding.
+    #[cfg(not(feature = "heap"))]
+    buf_celt_pcm: FixedVec<f32, OPUS_PCM_BUF>,
+    #[cfg(feature = "heap")]
+    buf_celt_pcm: Box<FixedVec<f32, OPUS_PCM_BUF>>,
+    /// C `encoder_buffer` (= Fs/100): samples of ring history kept between
+    /// frames (0 for restricted-latency applications).
+    encoder_buffer: usize,
+    /// C `delay_compensation` (= Fs/250): 4 ms lookahead prefix prepended to
+    /// each CELT frame (0 for restricted-latency applications).
+    delay_compensation: usize,
+    /// Float filter state for `dc_reject_float` / `hp_cutoff_float`
+    /// (C `st->hp_mem[4]`, opus_val32 in the float build).
+    hp_mem_float: [f32; 4],
     down2_state_first: [i32; 2],
     down2_state_second: [i32; 2],
     down2_3_state: [i32; 6],
@@ -399,6 +426,25 @@ impl OpusEncoder {
             buf_celt_input: FixedVec::new(),
             #[cfg(feature = "heap")]
             buf_celt_input: Box::new(FixedVec::new()),
+            #[cfg(not(feature = "heap"))]
+            delay_buffer: FixedVec::from_value(0.0, OPUS_DELAY_BUF),
+            #[cfg(feature = "heap")]
+            delay_buffer: Box::new(FixedVec::from_value(0.0, OPUS_DELAY_BUF)),
+            #[cfg(not(feature = "heap"))]
+            buf_celt_pcm: FixedVec::new(),
+            #[cfg(feature = "heap")]
+            buf_celt_pcm: Box::new(FixedVec::new()),
+            encoder_buffer: if matches!(application, Application::RestrictedLowDelay) {
+                0
+            } else {
+                (sampling_rate / 100) as usize
+            },
+            delay_compensation: if matches!(application, Application::RestrictedLowDelay) {
+                0
+            } else {
+                (sampling_rate / 250) as usize
+            },
+            hp_mem_float: [0.0; 4],
             down2_state_first: [0; 2],
             down2_state_second: [0; 2],
             down2_3_state: [0; 6],
@@ -522,6 +568,25 @@ impl OpusEncoder {
         let init_rc_size = n_bytes - 1;
         self.rc.reset_for_encode(init_rc_size as u32);
 
+        // C opus_encode_frame_native: high-pass cutoff state is updated for ALL
+        // modes (celt_encoder.c:1969-1977); the filtered signal is what feeds
+        // both SILK (hybrid) and CELT. Compute it here so CELT-only frames also
+        // keep `variable_hp_smth2_q15` in sync with libopus.
+        let hp_freq_smth1 = if mode == OpusMode::CeltOnly {
+            silk_lin2log(60) << 8
+        } else {
+            self.silk_enc.s_cmn.variable_hp_smth1_q15
+        };
+
+        const VARIABLE_HP_SMTH_COEF2_Q16: i32 = 984;
+        self.variable_hp_smth2_q15 = silk_smlawb(
+            self.variable_hp_smth2_q15,
+            hp_freq_smth1 - self.variable_hp_smth2_q15,
+            VARIABLE_HP_SMTH_COEF2_Q16,
+        );
+
+        let cutoff_hz = silk_log2lin(silk_rshift(self.variable_hp_smth2_q15, 8));
+
         if mode == OpusMode::SilkOnly || mode == OpusMode::Hybrid {
             let silk_fs_khz = if mode == OpusMode::Hybrid {
                 16
@@ -558,21 +623,6 @@ impl OpusEncoder {
             if self.silk_enc.s_cmn.lbrr_gain_increases == 0 {
                 self.silk_enc.s_cmn.lbrr_gain_increases = 2;
             }
-
-            let hp_freq_smth1 = if mode == OpusMode::CeltOnly {
-                silk_lin2log(60) << 8
-            } else {
-                self.silk_enc.s_cmn.variable_hp_smth1_q15
-            };
-
-            const VARIABLE_HP_SMTH_COEF2_Q16: i32 = 984;
-            self.variable_hp_smth2_q15 = silk_smlawb(
-                self.variable_hp_smth2_q15,
-                hp_freq_smth1 - self.variable_hp_smth2_q15,
-                VARIABLE_HP_SMTH_COEF2_Q16,
-            );
-
-            let cutoff_hz = silk_log2lin(silk_rshift(self.variable_hp_smth2_q15, 8));
 
             let required_size = frame_size * self.channels;
             self.buf_filtered.resize(required_size, 0);
@@ -778,7 +828,81 @@ impl OpusEncoder {
             // libopus: Hybrid VBR is unconstrained (can steal from SILK), CELT-only constrained
             self.celt_enc.set_constrained_vbr(mode == OpusMode::CeltOnly);
 
-            let celt_input: &[f32] = if self.channels == 1 {
+            // Build the CELT input exactly like C `opus_encode_frame_native`:
+            //   pcm_buf = [delay-compensation prefix from ring]
+            //             [dc_reject / hp_cutoff'd current frame]
+            // CELT then reads pcm_buf[0..frame_size*channels] (opus_encoder.c:
+            // 1966-2010, 2493). This delay + filter step is what libopus feeds
+            // its CELT encoder; passing the raw input diverges from 1.6.
+            let celt_input: &[f32] = if self.delay_compensation > 0 {
+                let delay = self.delay_compensation;
+                let ebuf = self.encoder_buffer;
+                let ch = self.channels;
+                let total = (delay + frame_size) * ch;
+                self.buf_celt_pcm.resize(total, 0.0);
+                // 1. delay prefix from the ring (C: OPUS_COPY at 1967)
+                let prefix = delay * ch;
+                let src_start = (ebuf - delay) * ch;
+                self.buf_celt_pcm[..prefix]
+                    .copy_from_slice(&self.delay_buffer[src_start..src_start + prefix]);
+                // 2. filter current frame into pcm_buf[delay..] (C: 2002-2010)
+                let out = &mut self.buf_celt_pcm[prefix..];
+                if self.application == Application::Voip {
+                    hp_cutoff_float(
+                        input,
+                        cutoff_hz,
+                        out,
+                        &mut self.hp_mem_float,
+                        frame_size,
+                        ch,
+                        self.sampling_rate,
+                    );
+                } else {
+                    dc_reject_float(
+                        input,
+                        3,
+                        out,
+                        &mut self.hp_mem_float,
+                        frame_size,
+                        ch,
+                        self.sampling_rate,
+                    );
+                }
+                // 3. float NaN guard (C: 2016-2028)
+                let mut sum = 0.0f32;
+                for &v in &self.buf_celt_pcm[prefix..] {
+                    sum += v * v;
+                }
+                if !(sum < 1e9) || sum.is_nan() {
+                    self.buf_celt_pcm[prefix..].fill(0.0);
+                    self.hp_mem_float = [0.0; 4];
+                }
+                // 4. delay ring update (C: 2300-2312)
+                let keep = ebuf as i64 - (frame_size as i64 + delay as i64);
+                if keep > 0 {
+                    let keep = keep as usize;
+                    self.delay_buffer
+                        .copy_within(ch * frame_size..ch * (frame_size + keep), 0);
+                    let dst = ch * keep;
+                    let n = (frame_size + delay) * ch;
+                    self.delay_buffer[dst..dst + n].copy_from_slice(&self.buf_celt_pcm[..n]);
+                } else {
+                    let n = ebuf * ch;
+                    let src = (frame_size + delay - ebuf) * ch;
+                    self.delay_buffer[..n]
+                        .copy_from_slice(&self.buf_celt_pcm[src..src + n]);
+                }
+                // 5. deinterleave pcm_buf[0..frame_size*ch] (interleaved) to
+                //    channel-major for the Rust CELT encoder.
+                let n = frame_size * ch;
+                self.buf_celt_input.resize(n, 0.0);
+                for i in 0..frame_size {
+                    for c in 0..ch {
+                        self.buf_celt_input[c * frame_size + i] = self.buf_celt_pcm[i * ch + c];
+                    }
+                }
+                state_ref(&self.buf_celt_input)
+            } else if self.channels == 1 {
                 input
             } else {
                 let n = frame_size * self.channels;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -741,9 +741,12 @@ impl OpusEncoder {
             0
         };
 
-        // libopus parity: adjust nbCompressedBytes for CELT/Hybrid based on tell (opus_encoder.c:1913-1921)
+        // libopus parity: adjust nbCompressedBytes for CELT/Hybrid based on tell (celt_encoder.c:1913-1921)
         // tmp = bitrate*frame_size + tell*Fs; nbCompressed = (tmp+4*Fs)/(8*Fs)
-        if mode != OpusMode::SilkOnly {
+        // This is the CBR branch (vbr==0) in celt_encoder.c; for VBR the encoder
+        // does *not* do this adjustment - it uses the vbr_bound logic instead.
+        // Doing it for VBR would double-shrink and corrupt the budget.
+        if mode != OpusMode::SilkOnly && self.use_cbr {
             let tell = self.rc.tell();
             if tell > 1 {
                 let tmp = self.bitrate_bps as i64 * frame_size as i64 + tell as i64 * self.sampling_rate as i64;
@@ -757,7 +760,6 @@ impl OpusEncoder {
                 }
             }
         }
-
         if mode == OpusMode::CeltOnly || mode == OpusMode::Hybrid {
             self.celt_enc.complexity = self.complexity;
             let start_band = if mode == OpusMode::Hybrid { 17 } else { 0 };

--- a/src/mdct.rs
+++ b/src/mdct.rs
@@ -145,7 +145,11 @@ impl MdctLookup {
                 xp2 -= 2;
             }
 
-            let loop3_iters = if mid > limit { n4 - mid } else { 0 };
+            // Loop 3 runs from `mid` to `n4` (C: for(;i<N4;i++)). When the
+            // frame is short enough that loop 2 is empty (mid == limit, i.e.
+            // n4 == 2*limit, e.g. 2.5 ms sub-frames at 48 kHz with shift=3),
+            // this still needs n4 - mid pairs.
+            let loop3_iters = n4.saturating_sub(mid);
             let mut wp1_l3 = 0usize;
             let mut wp2_l3 = overlap.saturating_sub(1);
             for _ in 0..loop3_iters {
@@ -979,9 +983,6 @@ mod mdct_tests {
 
         let max0 = output0.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
         let max1 = output1.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
-        eprintln!("sub0 max={} sub1 max={}", max0, max1);
-        eprintln!("sub0[60..70]={:?}", &output0[60..70]);
-        eprintln!("sub1[60..70]={:?}", &output1[60..70]);
 
         assert!(max0.abs() < 500.0, "sub0 blowup: {}", max0);
         assert!(max1.abs() < 500.0, "sub1 blowup: {}", max1);

--- a/src/pvq.rs
+++ b/src/pvq.rs
@@ -558,7 +558,43 @@ fn pvq_search_n4(x: &[f32], y: &mut [i32], k: i32) {
 
         let vone_i = _mm_set1_epi32(1);
 
-        for _ in 0..k {
+        let mut pulses_left = k;
+
+        // Pre-search by projecting on the pyramid (C vq_sse2.c: K > N>>1 branch).
+        if k > 2 {
+            // sum of |x|
+            let mut t = _mm_add_ps(vabs, _mm_shuffle_ps(vabs, vabs, 0b01001110));
+            t = _mm_add_ps(t, _mm_shuffle_ps(t, t, 0b10110001));
+            let sum = _mm_cvtss_f32(t);
+            // C: if X too small, just replace it with a pulse at 0
+            let sum = if !(sum > 1e-15 && sum < 64.0) {
+                1.0
+            } else {
+                sum
+            };
+            // C uses the _mm_rcp_ps approximation (not exact division)
+            let vrcp = _mm_mul_ps(_mm_set1_ps(k as f32 + 0.8), _mm_rcp_ps(_mm_set1_ps(sum)));
+            let vyi = _mm_cvttps_epi32(_mm_mul_ps(vabs_x, vrcp));
+            vy = vyi;
+            let vyi_f = _mm_cvtepi32_ps(vyi);
+            let vy2 = _mm_add_ps(vyi_f, vyi_f);
+            vy2f = vy2;
+            // xy = dot(x, iy), yy = dot(iy, iy)
+            let vxy4 = _mm_mul_ps(vabs_x, vyi_f);
+            let vyy4 = _mm_mul_ps(vyi_f, vyi_f);
+            let mut t = _mm_add_ps(vxy4, _mm_shuffle_ps(vxy4, vxy4, 0b01001110));
+            t = _mm_add_ps(t, _mm_shuffle_ps(t, t, 0b10110001));
+            xy = _mm_cvtss_f32(t);
+            let mut t = _mm_add_ps(vyy4, _mm_shuffle_ps(vyy4, vyy4, 0b01001110));
+            t = _mm_add_ps(t, _mm_shuffle_ps(t, t, 0b10110001));
+            yy = _mm_cvtss_f32(t);
+            // pulses_left -= sum(iy)
+            let mut ps = _mm_add_epi32(vyi, _mm_shuffle_epi32(vyi, 0b01001110));
+            ps = _mm_add_epi32(ps, _mm_shuffle_epi32(ps, 0b10110001));
+            pulses_left -= _mm_cvtsi128_si32(ps);
+        }
+
+        for _ in 0..pulses_left {
             let vxy = _mm_set1_ps(xy);
             let vrxy = _mm_add_ps(vabs_x, vxy);
             let vyy1 = _mm_add_ps(vy2f, _mm_set1_ps(yy + 1.0));
@@ -571,15 +607,16 @@ fn pvq_search_n4(x: &[f32], y: &mut [i32], k: i32) {
             let s3 = _mm_cvtss_f32(_mm_shuffle_ps(vscore, vscore, 0b11_11_11_11));
             let mut best_score = s0;
             let mut best_i: u32 = 0;
-            if s1 > best_score {
+            // C SSE2 keeps the HIGHEST index on ties (pos = max of matching lanes).
+            if s1 >= best_score {
                 best_score = s1;
                 best_i = 1;
             }
-            if s2 > best_score {
+            if s2 >= best_score {
                 best_score = s2;
                 best_i = 2;
             }
-            if s3 > best_score {
+            if s3 >= best_score {
                 best_i = 3;
             }
             let _ = best_score;
@@ -650,17 +687,17 @@ fn pvq_search_n4(x: &[f32], y: &mut [i32], k: i32) {
             let mut bsq = sq0;
             let mut bden = ryy0;
             let mut best_i: u32 = 0;
-            if bden * sq1 > ryy1 * bsq {
+            if bden * sq1 >= ryy1 * bsq {
                 bsq = sq1;
                 bden = ryy1;
                 best_i = 1;
             }
-            if bden * sq2 > ryy2 * bsq {
+            if bden * sq2 >= ryy2 * bsq {
                 bsq = sq2;
                 bden = ryy2;
                 best_i = 2;
             }
-            if bden * sq3 > ryy3 * bsq {
+            if bden * sq3 >= ryy3 * bsq {
                 best_i = 3;
             }
             let _ = bsq;
@@ -1765,8 +1802,8 @@ unsafe fn pvq_search_avx2(x: &[f32], y: &mut [i32], k: i32, n: usize) {
             let vs = _mm256_loadu_ps(scores.as_ptr().add(j));
             let mask = _mm256_movemask_ps(_mm256_cmp_ps(vs, vgmax, _CMP_EQ_OQ)) as u32;
             if mask != 0 {
-                best_id = j + mask.trailing_zeros() as usize;
-                break;
+                // C SSE2 keeps the HIGHEST index on ties (pos = max of lanes).
+                best_id = j + (31 - mask.leading_zeros()) as usize;
             }
             j += 8;
         }

--- a/src/quant_bands.rs
+++ b/src/quant_bands.rs
@@ -406,7 +406,9 @@ pub fn quant_fine_energy(
             let mut q = ((error[c * m.nb_ebands + i] + 0.5) * (1 << bits) as f32).floor() as i32;
             q = q.max(0).min((1 << bits) - 1);
             enc.enc_bits(q as u32, bits as u32);
-            let offset = (q as f32 + 0.5) / (1 << bits) as f32 - 0.5;
+            // C (quant_bands.c): offset = (q+.5)*(1<<(14-bits))*(1/16384) - .5;
+            // (multiply-then-scale, not /2^bits; matters for byte-exactness)
+            let offset = (q as f32 + 0.5) * (1i32 << (14 - bits)) as f32 * (1.0 / 16384.0) - 0.5;
             old_e_bands[c * m.nb_ebands + i] += offset;
             error[c * m.nb_ebands + i] -= offset;
         }
@@ -429,7 +431,9 @@ pub fn unquant_fine_energy(
                 continue;
             }
             let q = dec.dec_bits(bits as u32);
-            let offset = (q as f32 + 0.5) / (1 << bits) as f32 - 0.5;
+            // C (quant_bands.c): offset = (q+.5)*(1<<(14-bits))*(1/16384) - .5;
+            // (multiply-then-scale, not /2^bits; matters for byte-exactness)
+            let offset = (q as f32 + 0.5) * (1i32 << (14 - bits)) as f32 * (1.0 / 16384.0) - 0.5;
             old_e_bands[c * m.nb_ebands + i] += offset;
         }
     }

--- a/tests/canary_mono.rs
+++ b/tests/canary_mono.rs
@@ -1,0 +1,21 @@
+use opus_rs::{Application as RsApp, OpusDecoder as RsDec, OpusEncoder as RsEnc};
+
+#[test]
+fn mono_impulse_48k_64k_finite_small_packet() {
+    let sr = 48000;
+    let ch = 1;
+    let br = 64000;
+    let fs = 960; // 20ms @48k
+    let mut pcm = vec![0.0f32; fs * ch];
+    pcm[0] = 1.0;
+    let mut enc = RsEnc::new(sr, ch, RsApp::Audio).unwrap();
+    enc.bitrate_bps = br;
+    let mut buf = vec![0u8; 1276];
+    let n = enc.encode(&pcm, fs, &mut buf).unwrap();
+    assert!(n > 0 && n <= 200, "packet huge {} bytes: {:02x?}", n, &buf[..n.min(8)]);
+    let mut dec = RsDec::new(sr, ch).unwrap();
+    let mut out = vec![0.0f32; fs * ch];
+    let got = dec.decode(&buf[..n], fs, &mut out).unwrap();
+    let max = out[..got * ch].iter().fold(0.0f32, |a, &x| a.max(x.abs()));
+    assert!(max.is_finite() && max < 15.0, "decode huge/finite max {} pkt {:?}", max, &buf[..n.min(8)]);
+}

--- a/tests/celt_silence_regression.rs
+++ b/tests/celt_silence_regression.rs
@@ -241,7 +241,9 @@ fn audio_to_silence_to_audio_transition() {
     };
     let zero_frame = vec![0.0f32; FRAME_SIZE * 2];
     let n_sine = 3;
-    let n_zero = 4;
+    let n_zero = 35; // CELT-only silence shrinks only after the dc_reject ring residue
+                    // (from the previous frame's signal) decays below lsb_depth —
+                    // ~31 zero frames at 48 kHz, matching libopus 1.6.
     let n_sine2 = 3;
     let total = n_sine + n_zero + n_sine2;
     let mut pcm = Vec::new();
@@ -264,9 +266,21 @@ fn audio_to_silence_to_audio_transition() {
         let n = enc.encode(chunk, FRAME_SIZE, &mut out).unwrap();
         packets.push(out[..n].to_vec());
     }
-    // Check packet sequence: first sine large, first zero after sine should be large (not silence due to overlap), subsequent zeros should be small
+    // Check packet sequence: the first zero after sine stays large (the delay-ring
+    // prefix still carries the previous frame's dc_reject residue, so the CELT
+    // encoder does not see silence yet — matching libopus 1.6). Only after ~31
+    // zero frames does the residue fall below the lsb_depth threshold and the
+    // packet shrink to a DTX-sized payload.
     assert!(packets[n_sine].len() > 100, "first zero after sine should not be immediate silence due to overlap, got {}", packets[n_sine].len());
-    assert!(packets[n_sine+1].len() <= 10, "second zero should be silence shrunk, got {}", packets[n_sine+1].len());
+    assert!(packets[n_sine + 1].len() > 100, "second zero should also be large (dc_reject ring residue), got {}", packets[n_sine + 1].len());
+    let shrunk = packets
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| p.len() <= 10)
+        .map(|(i, _)| i)
+        .collect::<Vec<_>>();
+    assert!(!shrunk.is_empty(), "long silence never shrunk; sizes {:?}", packets.iter().map(|p| p.len()).collect::<Vec<_>>());
+    assert!(shrunk[0] > n_sine, "silence shrunk too early at frame {}", shrunk[0]);
     // Decode self
     let mut dec = OpusDecoder::new(SAMPLING_RATE, 2).unwrap();
     let mut decoded_all = Vec::new();

--- a/tests/celt_vbr_huge_fix_test.rs
+++ b/tests/celt_vbr_huge_fix_test.rs
@@ -1,0 +1,89 @@
+use opus_rs::{Application, OpusDecoder, OpusEncoder};
+
+fn max_abs(v: &[f32]) -> f32 {
+    v.iter().map(|x| x.abs()).fold(0.0f32, f32::max)
+}
+
+#[test]
+fn vbr_near_silence_192k_not_huge() {
+    // PCM that previously generated fc 7f fd f8 and decoded to ~1.7e5 in libopus
+    let frame_size = 960;
+    let channels = 2;
+    let mut pcm = vec![0.0f32; frame_size * channels];
+    for i in 0..frame_size {
+        let v = 1e-06 * (2.0 * std::f32::consts::PI * 440.0 * i as f32 / 48000.0).sin();
+        for c in 0..channels {
+            pcm[i * channels + c] = v;
+        }
+    }
+    let mut enc = OpusEncoder::new(48000, channels, Application::Audio).unwrap();
+    enc.bitrate_bps = 192000;
+    enc.use_cbr = false;
+    let mut out = vec![0u8; 1276];
+    let n = enc.encode(&pcm, frame_size, &mut out).unwrap();
+    // must not be the old huge prefix
+    assert_ne!(&out[..3.min(n)], &[0xfc, 0x7f, 0xfd], "packet still has huge prefix fc 7f fd");
+    let mut dec = OpusDecoder::new(48000, channels).unwrap();
+    let mut pcm_out = vec![0.0f32; frame_size * channels];
+    let decoded = dec.decode(&out[..n], frame_size, &mut pcm_out).unwrap();
+    assert!(pcm_out.iter().all(|x| x.is_finite()), "non-finite after decode");
+    let ma = max_abs(&pcm_out);
+    assert!(ma < 10.0, "max_abs {} too large for near-silence (expected <10)", ma);
+    assert!(decoded > 0, "decode returned 0");
+}
+
+#[test]
+fn high_bitrate_matrix_48k_stereo() {
+    // 20ms 48k stereo tone at 0.3 amp 440Hz, across bitrates
+    for &kbps in &[128, 160, 176, 192, 256] {
+        let frame_size = 960;
+        let channels = 2;
+        let mut pcm = vec![0.0f32; frame_size * channels];
+        for i in 0..frame_size {
+            let v = 0.3 * (2.0 * std::f32::consts::PI * 440.0 * i as f32 / 48000.0).sin();
+            for c in 0..channels {
+                pcm[i * channels + c] = v + (c as f32 * 0.001);
+            }
+        }
+        let mut enc = OpusEncoder::new(48000, channels, Application::Audio).unwrap();
+        enc.bitrate_bps = kbps * 1000;
+        enc.use_cbr = false;
+        let mut out = vec![0u8; 1276];
+        let n = enc.encode(&pcm, frame_size, &mut out).unwrap();
+        let mut dec = OpusDecoder::new(48000, channels).unwrap();
+        let mut pcm_out = vec![0.0f32; frame_size * channels];
+        let res = dec.decode(&out[..n], frame_size, &mut pcm_out);
+        assert!(res.is_ok(), "decode failed at {} kbps: {:?}", kbps, res);
+        assert!(pcm_out.iter().all(|x| x.is_finite()), "non-finite at {} kbps", kbps);
+        let ma = max_abs(&pcm_out);
+        assert!(ma < 10.0, "max_abs {} too large at {} kbps", ma, kbps);
+        assert!(ma < 1e5, "huge amplitude at {} kbps", kbps);
+    }
+}
+
+#[test]
+fn per_packet_fresh_decoder_192k() {
+    // Same PCM as high bitrate, but decode each packet with a fresh decoder
+    let frame_size = 960;
+    let channels = 2;
+    let mut pcm = vec![0.0f32; frame_size * channels];
+    for i in 0..frame_size {
+        let v = 0.5 * (2.0 * std::f32::consts::PI * 1000.0 * i as f32 / 48000.0).sin();
+        for c in 0..channels {
+            pcm[i * channels + c] = v;
+        }
+    }
+    let mut enc = OpusEncoder::new(48000, channels, Application::Audio).unwrap();
+    enc.bitrate_bps = 192000;
+    enc.use_cbr = false;
+    let mut out = vec![0u8; 1276];
+    let n = enc.encode(&pcm, frame_size, &mut out).unwrap();
+    let pkt = out[..n].to_vec();
+    // Decode with fresh decoder per packet (single packet)
+    let mut dec = OpusDecoder::new(48000, channels).unwrap();
+    let mut pcm_out = vec![0.0f32; frame_size * channels];
+    let res = dec.decode(&pkt, frame_size, &mut pcm_out).unwrap();
+    assert!(res > 0);
+    assert!(pcm_out.iter().all(|x| x.is_finite()));
+    assert!(max_abs(&pcm_out) < 10.0);
+}

--- a/tests/celt_vbr_huge_fix_test.rs
+++ b/tests/celt_vbr_huge_fix_test.rs
@@ -6,7 +6,12 @@ fn max_abs(v: &[f32]) -> f32 {
 
 #[test]
 fn vbr_near_silence_192k_not_huge() {
-    // PCM that previously generated fc 7f fd f8 and decoded to ~1.7e5 in libopus
+    // PCM that previously generated fc 7f fd f8 and decoded to ~1.7e5 in libopus.
+    // With the C-faithful delay ring + dc_reject the near-silence is not treated
+    // as digital silence, so the VBR packet is large (fc 7f fd padding header),
+    // but it must decode back to near-silence without a burst. (libopus 1.6 also
+    // emits a large fc-prefixed VBR packet here; its target is ~766 bytes while
+    // the Rust's simplified compute_vbr targets ~480 — a known VBR gap.)
     let frame_size = 960;
     let channels = 2;
     let mut pcm = vec![0.0f32; frame_size * channels];
@@ -21,8 +26,7 @@ fn vbr_near_silence_192k_not_huge() {
     enc.use_cbr = false;
     let mut out = vec![0u8; 1276];
     let n = enc.encode(&pcm, frame_size, &mut out).unwrap();
-    // must not be the old huge prefix
-    assert_ne!(&out[..3.min(n)], &[0xfc, 0x7f, 0xfd], "packet still has huge prefix fc 7f fd");
+    assert!(n > 0 && n <= 1276);
     let mut dec = OpusDecoder::new(48000, channels).unwrap();
     let mut pcm_out = vec![0.0f32; frame_size * channels];
     let decoded = dec.decode(&out[..n], frame_size, &mut pcm_out).unwrap();

--- a/tests/high_bitrate_interop_test.rs
+++ b/tests/high_bitrate_interop_test.rs
@@ -47,7 +47,9 @@ fn make_complex_stereo(n_frames: usize) -> Vec<f32> {
 
 fn snr_db(input: &[f32], output: &[f32], delay_lo: i32, delay_hi: i32) -> f64 {
     // Measure over a late window (past the encoder+decoder algorithmic delay)
-    // and search the delay band around the known 240-sample (5 ms) delay.
+    // and search the delay band around the C-faithful 624-sample (13 ms) delay:
+    // the CELT lookahead (240) plus the dc_reject/hp delay ring (192) and the
+    // remaining opus-layer delay_compensation (~192).
     let n_active = input.len().min(24000);
     let active = (input.len() - n_active)..input.len();
     let mut best = f64::NEG_INFINITY;
@@ -225,14 +227,14 @@ fn high_bitrate_interop() {
             let packets = encode_frames(&mut enc, pcm);
 
             let crate_out = decode_with_crate(&packets);
-            let crate_snr = snr_db(pcm, &crate_out, 0, 500);
+            let crate_snr = snr_db(pcm, &crate_out, 0, 700);
 
             let mut libopus_snr = f64::NEG_INFINITY;
             let ffmpeg_available;
             match decode_with_ffmpeg(&packets) {
                 Some(ff_out) => {
                     ffmpeg_available = true;
-                    libopus_snr = snr_db(pcm, &ff_out, 0, 500);
+                    libopus_snr = snr_db(pcm, &ff_out, 0, 700);
                 }
                 None => {
                     ffmpeg_available = false;

--- a/tests/oracle_celt.rs
+++ b/tests/oracle_celt.rs
@@ -22,18 +22,21 @@ fn oracle_celt_sine_48k_mono_64k() {
     let pcm = make_sine(sr, ch, fs, 440.0);
     let mut rs_enc = RsEnc::new(sr, ch, RsApp::Audio).unwrap();
     rs_enc.bitrate_bps = br;
+    rs_enc.use_cbr = true;
+    rs_enc.complexity = 10;
     let mut rs_buf = vec![0u8; 1276];
     let rs_n = rs_enc.encode(&pcm, fs, &mut rs_buf).unwrap();
     let mut c_enc = CEnc::new(sr as u32, if ch==1 {CCh::Mono} else {CCh::Stereo}, CApp::Audio).unwrap();
     c_enc.set_bitrate(opus::Bitrate::Bits(br)).unwrap();
     c_enc.set_vbr(false).unwrap();
+    let _ = c_enc.set_complexity(10);
     let mut c_buf = vec![0u8; 1276];
     let c_n = c_enc.encode_float(&pcm, &mut c_buf).unwrap();
     println!("rs pkt {} {:02x?} c pkt {} {:02x?}", rs_n, &rs_buf[..rs_n.min(8)], c_n, &c_buf[..c_n.min(8)]);
     assert!(rs_n > 0 && rs_n <= 1276);
     assert!(c_n > 0 && c_n <= 1276);
     let diff = (rs_n as i32 - c_n as i32).abs();
-    assert!(diff <= 20, "size diff too large rs {} vs c {}", rs_n, c_n);
+    assert!(diff <= 5, "size diff too large rs {} vs c {} diff {}", rs_n, c_n, diff);
 }
 
 #[test]
@@ -46,11 +49,14 @@ fn oracle_impulse_48k_mono_64k() {
     pcm[0]=1.0;
     let mut rs_enc = RsEnc::new(sr, ch, RsApp::Audio).unwrap();
     rs_enc.bitrate_bps = br;
+    rs_enc.use_cbr = true;
+    rs_enc.complexity = 10;
     let mut rs_buf = vec![0u8; 1276];
     let rs_n = rs_enc.encode(&pcm, fs, &mut rs_buf).unwrap();
     let mut c_enc = CEnc::new(sr as u32, CCh::Mono, CApp::Audio).unwrap();
     c_enc.set_bitrate(opus::Bitrate::Bits(br)).unwrap();
     c_enc.set_vbr(false).unwrap();
+    let _ = c_enc.set_complexity(10);
     let mut c_buf = vec![0u8; 1276];
     let c_n = c_enc.encode_float(&pcm, &mut c_buf).unwrap();
     println!("impulse rs {} {:02x?} c {} {:02x?}", rs_n, &rs_buf[..rs_n.min(8)], c_n, &c_buf[..c_n.min(8)]);
@@ -60,6 +66,8 @@ fn oracle_impulse_48k_mono_64k() {
     let got = rs_dec.decode(&rs_buf[..rs_n], fs, &mut out).unwrap();
     let max = out[..got*ch].iter().fold(0.0f32, |a,&x| a.max(x.abs()));
     assert!(max < 15.0 && max.is_finite());
+    // For 48k CBR, also check byte closeness (allow small divergence due to remaining tone/Hybrid gaps)
+    assert!((rs_n as i32 - c_n as i32).abs() <= 5);
 }
 
 #[test]
@@ -75,6 +83,8 @@ fn oracle_all_sr_ch_br() {
                 let pcm = make_sine(sr, ch, fs as usize, freq);
                 let mut rs_enc = RsEnc::new(sr, ch as usize, RsApp::Audio).unwrap();
                 rs_enc.bitrate_bps = br;
+                rs_enc.use_cbr = true;
+                rs_enc.complexity = 10;
                 let mut rs_buf = vec![0u8; 1276];
                 let rs_n = rs_enc.encode(&pcm, fs as usize, &mut rs_buf).unwrap();
                 let c_ch = if ch==1 {CCh::Mono} else {CCh::Stereo};
@@ -84,6 +94,7 @@ fn oracle_all_sr_ch_br() {
                 };
                 if c_enc.set_bitrate(opus::Bitrate::Bits(br)).is_err() { continue; }
                 let _ = c_enc.set_vbr(false);
+                let _ = c_enc.set_complexity(10);
                 let mut c_buf = vec![0u8; 1276];
                 let c_n = match c_enc.encode_float(&pcm, &mut c_buf) {
                     Ok(n) => n,
@@ -92,9 +103,9 @@ fn oracle_all_sr_ch_br() {
                 let diff = (rs_n as i32 - c_n as i32).abs();
                 println!("oracle sr {} ch {} br {} rs {} c {} diff {}", sr,ch,br,rs_n,c_n,diff);
                 assert!(rs_n>0 && c_n>0, "zero packet sr {} ch {} br {}", sr,ch,br);
-                let tol = if sr == 48000 { 25 } else { 50 };
+                let tol = if sr == 48000 { 5 } else { 50 };
                 if diff > tol {
-                    println!("WARN diff {} >{} for sr {} ch {} br {} (known gap)", diff, tol, sr,ch,br);
+                    println!("WARN diff {} >{} for sr {} ch {} br {} (known Hybrid gap)", diff, tol, sr,ch,br);
                 }
                 if sr == 48000 {
                     assert!(diff <= tol, "size diff {} >{} sr {} ch {} br {} rs {} c {}", diff, tol, sr,ch,br,rs_n,c_n);

--- a/tests/oracle_celt.rs
+++ b/tests/oracle_celt.rs
@@ -13,6 +13,15 @@ fn make_sine(sr: i32, ch: usize, frame_size: usize, freq: f32) -> Vec<f32> {
     v
 }
 
+fn hex_to_bytes(s: &str) -> Vec<u8> {
+    let s = s.trim();
+    assert!(s.len() % 2 == 0, "odd hex length");
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+        .collect()
+}
+
 #[test]
 fn oracle_celt_sine_48k_mono_64k() {
     let sr = 48000;
@@ -37,6 +46,24 @@ fn oracle_celt_sine_48k_mono_64k() {
     assert!(c_n > 0 && c_n <= 1276);
     let diff = (rs_n as i32 - c_n as i32).abs();
     assert!(diff <= 5, "size diff too large rs {} vs c {} diff {}", rs_n, c_n, diff);
+    // Byte-exact for Rust's own 48k CELT output (regression vs fixture from current port).
+    // Old C (libopus 1.3 via audiopus_sys 0.2.2) differs due to tone/prefilter evolution, so we verify
+    // Rust's determinism and known prefix instead of strict C byte equality.
+    let expected_prefix: [u8; 8] = [0xf8, 0xb3, 0x3a, 0x7a, 0x2b, 0xec, 0x8e, 0x1b];
+    assert_eq!(&rs_buf[..8.min(rs_n)], &expected_prefix[..8.min(rs_n)], "byte prefix mismatch for 48k sine 64k");
+    const EXPECTED_SINE_HEX: &str = "f8b33a7a2bec8e1bdeb7af5777649e182697436b1a099692a835dea050592c7aa969369667d6dfd72528a9f66009b3bdc520e502f960bec9b2448c4fc64a7e0d4186d6a5c2f26260da2bc4b796bb70e7dc32be08bb581bb30d0bda179d96c5d3b6bb8a6fb3fbae5b2f4c018c7b95211cf6334bdb785540fa8c6edf26491844025f11d4926d5c7dfbdfa35358a0f3975230d3f8331282cb8f09dbc155c2020dae";
+    let expected = hex_to_bytes(EXPECTED_SINE_HEX);
+    assert_eq!(rs_n, expected.len(), "fixture len mismatch for 48k sine");
+    assert_eq!(&rs_buf[..rs_n], &expected[..], "full byte-exact mismatch for 48k sine 64k");
+    // Determinism: re-encode same input must be byte-identical
+    let mut rs_enc2 = RsEnc::new(sr, ch, RsApp::Audio).unwrap();
+    rs_enc2.bitrate_bps = br;
+    rs_enc2.use_cbr = true;
+    rs_enc2.complexity = 10;
+    let mut rs_buf2 = vec![0u8; 1276];
+    let rs_n2 = rs_enc2.encode(&pcm, fs, &mut rs_buf2).unwrap();
+    assert_eq!(rs_n, rs_n2, "non-deterministic size");
+    assert_eq!(&rs_buf[..rs_n], &rs_buf2[..rs_n2], "non-deterministic bytes");
 }
 
 #[test]
@@ -68,6 +95,21 @@ fn oracle_impulse_48k_mono_64k() {
     assert!(max < 15.0 && max.is_finite());
     // For 48k CBR, also check byte closeness (allow small divergence due to remaining tone/Hybrid gaps)
     assert!((rs_n as i32 - c_n as i32).abs() <= 5);
+    // Byte-exact for Rust's own 48k impulse (regression)
+    let expected_impulse_prefix: [u8; 8] = [0xf8, 0x7f, 0x7d, 0x04, 0x38, 0x05, 0x2a, 0x21];
+    assert_eq!(&rs_buf[..8.min(rs_n)], &expected_impulse_prefix[..8.min(rs_n)], "byte prefix mismatch for 48k impulse");
+    const EXPECTED_IMPULSE_HEX: &str = "f87f7d0438052a212201282ac860c1888ac2a4220abeb23e0ab217c0a5711a31259a499a51a065b87a7bb247a10c297fba1169527fd742fb32cd0b54f6342c0c00daaf19bec71d433d353671d7e53a442267df33e6da7a8af01aeade58265a84ccc96cc961d342ae77d60b85d4ac4b5588eac4b5e51ac6832f7f82f1ac80415213aa2a8a7a023f0c15d0b1f6888da4aabe0f0e370e2b1e24d6c7d8d10074d6d1";
+    let expected = hex_to_bytes(EXPECTED_IMPULSE_HEX);
+    assert_eq!(rs_n, expected.len(), "fixture len mismatch for impulse");
+    assert_eq!(&rs_buf[..rs_n], &expected[..], "full byte-exact mismatch for impulse");
+    let mut rs_enc2 = RsEnc::new(sr, ch, RsApp::Audio).unwrap();
+    rs_enc2.bitrate_bps = br;
+    rs_enc2.use_cbr = true;
+    rs_enc2.complexity = 10;
+    let mut rs_buf2 = vec![0u8; 1276];
+    let rs_n2 = rs_enc2.encode(&pcm, fs, &mut rs_buf2).unwrap();
+    assert_eq!(rs_n, rs_n2);
+    assert_eq!(&rs_buf[..rs_n], &rs_buf2[..rs_n2]);
 }
 
 #[test]

--- a/tests/oracle_celt.rs
+++ b/tests/oracle_celt.rs
@@ -1,0 +1,110 @@
+use opus::{Application as CApp, Channels as CCh, Encoder as CEnc};
+use opus_rs::{Application as RsApp, OpusDecoder as RsDec, OpusEncoder as RsEnc};
+
+fn make_sine(sr: i32, ch: usize, frame_size: usize, freq: f32) -> Vec<f32> {
+    let mut v = vec![0.0f32; frame_size * ch];
+    for i in 0..frame_size {
+        let t = i as f32 / sr as f32;
+        let s = (2.0 * std::f32::consts::PI * freq * t).sin() * 0.5;
+        for c in 0..ch {
+            v[i * ch + c] = s;
+        }
+    }
+    v
+}
+
+#[test]
+fn oracle_celt_sine_48k_mono_64k() {
+    let sr = 48000;
+    let ch = 1;
+    let br = 64000;
+    let fs = 960;
+    let pcm = make_sine(sr, ch, fs, 440.0);
+    let mut rs_enc = RsEnc::new(sr, ch, RsApp::Audio).unwrap();
+    rs_enc.bitrate_bps = br;
+    let mut rs_buf = vec![0u8; 1276];
+    let rs_n = rs_enc.encode(&pcm, fs, &mut rs_buf).unwrap();
+    let mut c_enc = CEnc::new(sr as u32, if ch==1 {CCh::Mono} else {CCh::Stereo}, CApp::Audio).unwrap();
+    c_enc.set_bitrate(opus::Bitrate::Bits(br)).unwrap();
+    c_enc.set_vbr(false).unwrap();
+    let mut c_buf = vec![0u8; 1276];
+    let c_n = c_enc.encode_float(&pcm, &mut c_buf).unwrap();
+    println!("rs pkt {} {:02x?} c pkt {} {:02x?}", rs_n, &rs_buf[..rs_n.min(8)], c_n, &c_buf[..c_n.min(8)]);
+    assert!(rs_n > 0 && rs_n <= 1276);
+    assert!(c_n > 0 && c_n <= 1276);
+    let diff = (rs_n as i32 - c_n as i32).abs();
+    assert!(diff <= 20, "size diff too large rs {} vs c {}", rs_n, c_n);
+}
+
+#[test]
+fn oracle_impulse_48k_mono_64k() {
+    let sr = 48000;
+    let ch = 1;
+    let br = 64000;
+    let fs = 960;
+    let mut pcm = vec![0.0f32; fs*ch];
+    pcm[0]=1.0;
+    let mut rs_enc = RsEnc::new(sr, ch, RsApp::Audio).unwrap();
+    rs_enc.bitrate_bps = br;
+    let mut rs_buf = vec![0u8; 1276];
+    let rs_n = rs_enc.encode(&pcm, fs, &mut rs_buf).unwrap();
+    let mut c_enc = CEnc::new(sr as u32, CCh::Mono, CApp::Audio).unwrap();
+    c_enc.set_bitrate(opus::Bitrate::Bits(br)).unwrap();
+    c_enc.set_vbr(false).unwrap();
+    let mut c_buf = vec![0u8; 1276];
+    let c_n = c_enc.encode_float(&pcm, &mut c_buf).unwrap();
+    println!("impulse rs {} {:02x?} c {} {:02x?}", rs_n, &rs_buf[..rs_n.min(8)], c_n, &c_buf[..c_n.min(8)]);
+    assert!(rs_n <= 200 && c_n <= 200, "huge packet rs {} c {}", rs_n, c_n);
+    let mut rs_dec = RsDec::new(sr, ch).unwrap();
+    let mut out = vec![0.0f32; fs*ch];
+    let got = rs_dec.decode(&rs_buf[..rs_n], fs, &mut out).unwrap();
+    let max = out[..got*ch].iter().fold(0.0f32, |a,&x| a.max(x.abs()));
+    assert!(max < 15.0 && max.is_finite());
+}
+
+#[test]
+fn oracle_all_sr_ch_br() {
+    let srs = [48000, 24000, 16000];
+    let chs = [1, 2];
+    let brs = [32000, 64000, 96000];
+    let freq = 440.0;
+    for &sr in &srs {
+        for &ch in &chs {
+            for &br in &brs {
+                let fs = sr / 50;
+                let pcm = make_sine(sr, ch, fs as usize, freq);
+                let mut rs_enc = RsEnc::new(sr, ch as usize, RsApp::Audio).unwrap();
+                rs_enc.bitrate_bps = br;
+                let mut rs_buf = vec![0u8; 1276];
+                let rs_n = rs_enc.encode(&pcm, fs as usize, &mut rs_buf).unwrap();
+                let c_ch = if ch==1 {CCh::Mono} else {CCh::Stereo};
+                let mut c_enc = match CEnc::new(sr as u32, c_ch, CApp::Audio) {
+                    Ok(e) => e,
+                    Err(e) => { println!("skip sr {} ch {} br {}: CEnc new err {:?}", sr,ch,br,e); continue; }
+                };
+                if c_enc.set_bitrate(opus::Bitrate::Bits(br)).is_err() { continue; }
+                let _ = c_enc.set_vbr(false);
+                let mut c_buf = vec![0u8; 1276];
+                let c_n = match c_enc.encode_float(&pcm, &mut c_buf) {
+                    Ok(n) => n,
+                    Err(e) => { println!("skip encode sr {} ch {} br {}: {:?}", sr,ch,br,e); continue; }
+                };
+                let diff = (rs_n as i32 - c_n as i32).abs();
+                println!("oracle sr {} ch {} br {} rs {} c {} diff {}", sr,ch,br,rs_n,c_n,diff);
+                assert!(rs_n>0 && c_n>0, "zero packet sr {} ch {} br {}", sr,ch,br);
+                let tol = if sr == 48000 { 25 } else { 50 };
+                if diff > tol {
+                    println!("WARN diff {} >{} for sr {} ch {} br {} (known gap)", diff, tol, sr,ch,br);
+                }
+                if sr == 48000 {
+                    assert!(diff <= tol, "size diff {} >{} sr {} ch {} br {} rs {} c {}", diff, tol, sr,ch,br,rs_n,c_n);
+                }
+                let mut dec = RsDec::new(sr, ch as usize).unwrap();
+                let mut out = vec![0.0f32; fs as usize * ch as usize];
+                let got = dec.decode(&rs_buf[..rs_n], fs as usize, &mut out).unwrap();
+                let max = out[..got*ch as usize].iter().fold(0.0f32, |a,&x| a.max(x.abs()));
+                assert!(max.is_finite() && max < 50.0, "decode huge sr {} ch {} br {} max {}", sr,ch,br,max);
+            }
+        }
+    }
+}

--- a/tests/oracle_celt.rs
+++ b/tests/oracle_celt.rs
@@ -46,12 +46,13 @@ fn oracle_celt_sine_48k_mono_64k() {
     assert!(c_n > 0 && c_n <= 1276);
     let diff = (rs_n as i32 - c_n as i32).abs();
     assert!(diff <= 5, "size diff too large rs {} vs c {} diff {}", rs_n, c_n, diff);
-    // Byte-exact for Rust's own 48k CELT output (regression vs fixture from current port).
-    // Old C (libopus 1.3 via audiopus_sys 0.2.2) differs due to tone/prefilter evolution, so we verify
-    // Rust's determinism and known prefix instead of strict C byte equality.
-    let expected_prefix: [u8; 8] = [0xf8, 0xb3, 0x3a, 0x7a, 0x2b, 0xec, 0x8e, 0x1b];
+    // Byte-exact regression for 48k mono 64k CBR sine, validated against a
+    // libopus 1.6.1-51-g03647f52 (float, x86 SSE2/AVX2) reference build. The
+    // audiopus_sys 0.2.2 C (libopus 1.3) differs in tone/prefilter evolution,
+    // so we assert the 1.6 fixture here and only require size proximity vs 1.3.
+    let expected_prefix: [u8; 8] = [0xf8, 0x7b, 0x5e, 0x09, 0x50, 0xb7, 0x8c, 0x08];
     assert_eq!(&rs_buf[..8.min(rs_n)], &expected_prefix[..8.min(rs_n)], "byte prefix mismatch for 48k sine 64k");
-    const EXPECTED_SINE_HEX: &str = "f8b33a7a2bec8e1bdeb7af5777649e182697436b1a099692a835dea050592c7aa969369667d6dfd72528a9f66009b3bdc520e502f960bec9b2448c4fc64a7e0d4186d6a5c2f26260da2bc4b796bb70e7dc32be08bb581bb30d0bda179d96c5d3b6bb8a6fb3fbae5b2f4c018c7b95211cf6334bdb785540fa8c6edf26491844025f11d4926d5c7dfbdfa35358a0f3975230d3f8331282cb8f09dbc155c2020dae";
+    const EXPECTED_SINE_HEX: &str = "f87b5e0950b78c08d0bbae9ae1d725a72fe5ee25c2740398a4615b113822973b042c80fdb66da4a3a2cb9c192af55d6bf6dd65c5c7653367144ecc6b0565efad221c5de2215ab8fc6f9f4f48cad42d1c1999da21cfa221cfa037aa44b81ad91d4a8d1d581540cf6c39176eeab2770f00b461d43fa328ae650837e79c9e8f6c417951dc2e4d32634de493b88e0d167016e2646590e686571dcf2104af43ab137d";
     let expected = hex_to_bytes(EXPECTED_SINE_HEX);
     assert_eq!(rs_n, expected.len(), "fixture len mismatch for 48k sine");
     assert_eq!(&rs_buf[..rs_n], &expected[..], "full byte-exact mismatch for 48k sine 64k");
@@ -95,10 +96,14 @@ fn oracle_impulse_48k_mono_64k() {
     assert!(max < 15.0 && max.is_finite());
     // For 48k CBR, also check byte closeness (allow small divergence due to remaining tone/Hybrid gaps)
     assert!((rs_n as i32 - c_n as i32).abs() <= 5);
-    // Byte-exact for Rust's own 48k impulse (regression)
-    let expected_impulse_prefix: [u8; 8] = [0xf8, 0x7f, 0x7d, 0x04, 0x38, 0x05, 0x2a, 0x21];
+    // Byte-exact for Rust's own 48k impulse (regression). The first 7 bytes match
+    // a libopus 1.6.1 reference build; byte 7+ diverges from 1.6 because the Rust
+    // port does not run libopus' tonality analysis (analysis.c), which nudges
+    // alloc_trim via tonality_slope (C trim=1 vs Rust trim=0 here). This fixture
+    // freezes the current deterministic output.
+    let expected_impulse_prefix: [u8; 8] = [0xf8, 0x73, 0x46, 0xb9, 0xc0, 0x16, 0x58, 0x58];
     assert_eq!(&rs_buf[..8.min(rs_n)], &expected_impulse_prefix[..8.min(rs_n)], "byte prefix mismatch for 48k impulse");
-    const EXPECTED_IMPULSE_HEX: &str = "f87f7d0438052a212201282ac860c1888ac2a4220abeb23e0ab217c0a5711a31259a499a51a065b87a7bb247a10c297fba1169527fd742fb32cd0b54f6342c0c00daaf19bec71d433d353671d7e53a442267df33e6da7a8af01aeade58265a84ccc96cc961d342ae77d60b85d4ac4b5588eac4b5e51ac6832f7f82f1ac80415213aa2a8a7a023f0c15d0b1f6888da4aabe0f0e370e2b1e24d6c7d8d10074d6d1";
+    const EXPECTED_IMPULSE_HEX: &str = "f87346b9c0165858f73144258b8b79c2179a4272570325a2d263ab6067bb993375941787ac6e1904601599cafeb058f8eeb514adbb22ecb11412d9d75cf1169fdb36a4d7a7d06817cffc23fd39b6e3e7829db5edf6ed58cb3f58cb3f6a03976a5e05ee0ba8221ad585de11653bfacdcab607c26370d5f7945c3ca511ba07ffb4d8ff77d0c3d7e883f06d09b55d8db6a05ad7119fb82d72fb7375ccb483588e35";
     let expected = hex_to_bytes(EXPECTED_IMPULSE_HEX);
     assert_eq!(rs_n, expected.len(), "fixture len mismatch for impulse");
     assert_eq!(&rs_buf[..rs_n], &expected[..], "full byte-exact mismatch for impulse");


### PR DESCRIPTION
## Summary

Align CELT encoder with **libopus 1.6.1-51-g03647f52** (float, SSE2/AVX2) for the primary byte-exact oracle: **48 kHz mono, 64 kbps CBR, 440 Hz sine, 20 ms (960 samples)** — 160-byte packet now matches the C reference byte-for-byte. Addresses the reported CELT interoperability issue where some packets could cause a transient decoder burst/state drift in libopus.

Draft PR from `Rumia-Channel:pr/celt-byte-exact-1.6` → `restsend:main`. The branch is based on `origin/main@314915f` which already merges upstream `bcd09b3` (`core::cmp` / `0.1.31`).

> **Note on `silk_smulww`:** advisory was weighed — `silk_SMULWW` is correctly `>>16` (`silk_SMMUL` is `>>32`), no change made. This PR does not modify SILK arithmetic; its codec changes target CELT parity plus the Opus-layer preprocessing required to feed CELT correctly.

## Motivation

Before this PR, MDCT `loop3` dropped the folded tail for 2.5ms sub-frames, PVQ tie-break / pre-search diverged from SSE2, transient/tf/prefilter used simplified formulae, and opus-layer `pcm_buf` missed the 192-sample delay ring + `dc_reject`/`hp_cutoff`. Together they produced packets that decoded with burst / state drift in libopus. Regression coverage exists in `tests/celt_silence_regression.rs` (ffmpeg/libopus cross-decode, burst checks, `fc 7f fe` known-bad pattern).

## Reference

* C reference: upstream libopus `1.6.1-51-g03647f52` (`03647f52`), MSVC float build via Meson, x86 SSE2/AVX2 enabled.
* `audiopus_sys 0.2.2` (libopus 1.3) is intentionally not byte-exact — size-proximity only.

## Changes

**`src/lib.rs` + `src/hp_cutoff.rs` (new) — opus-layer input**
* Assemble `pcm_buf = [192 delay prefix from ring][dc_reject/hp_cutoff'd frame]` matching `opus_encoder.c:1966-2010, 2300-2312`, interleaved `FixedVec` (`OPUS_PCM_BUF = (192+2880)*2`), NaN guard, `delay_compensation = Fs/250`.
* Port `dc_reject_float` / `hp_cutoff_float`+`silk_biquad_res_float` (Q28 coeffs, `1e-30` tail).
* `hp_freq_smth1`/`variable_hp_smth2_q15`/`cutoff_hz` now runs for all modes (C parity).

**`src/mdct.rs`**
* `loop3_iters = n4.saturating_sub(mid)` — previously `mid > limit ? n4-mid : 0` zeroed the tail when `mid==limit` (2.5ms, shift=3).

**`src/celt.rs`**
* `transient_analysis`: `mean += x2` (no `/4096`), `norm = len2/(1e-15+mean)`, integer `unmask`, exact `tf_max = max(0, sqrt(27*mask)-42); tf = sqrt(max(0,0.0069*min(163,tf_max)-0.139))`.
* `run_prefilter`: tone path (`toneishness>0.99`), `tf_estimate>0.98` gain kill, `nb_available_bytes<25/35` bumps, C-exact loss halving, `complexity` param. New args `tf_estimate, nb_available_bytes, tone_freq, toneishness, complexity`.
* `quant`: `force_intra=false` (C `st->force_intra`).
* `tf_analysis`: takes `importance: &[i32]`, integer Viterbi, `tf_select=1` gated by `is_transient`.
* `dynalloc_analysis_simple`: emits `importance = floor(0.5+13*2^min(follower,4))`, moved before `tf_analysis`.
* `allocation`: `anti_collapse_rsv = isTransient&&LM>=2&&bits>=((LM+2)<<BITRES) ? 1<<BITRES : 0` subtracted **before** `clt_compute_allocation`.

**`src/pvq.rs`**
* `pvq_search_n4` SSE2 pre-search (`rcp=(K+0.8)*_mm_rcp_ps(sum)`, truncation) + pulse loop `>=` (highest index wins). Scalar/AVX2 tie-break fixed to highest-wins (`31 - lz`, no `break`).

**`src/quant_bands.rs`**
* `quant_fine_energy`/`unquant_fine_energy` offset = `(q+.5)*(1<<(14-bits))/16384 - .5` (multiply-then-scale, 1-ulp).

## Verification

* `tests/oracle_celt.rs` — primary sine oracle is byte-exact vs 1.6 reference:
  `f87b5e0950b78c08d0bbae9ae1d725a72fe5ee25c2740398a4615b113822973b042c80fdb66da4a3a2cb9c192af55d6bf6dd65c5c7653367144ecc6b0565efad221c5de2215ab8fc6f9f4f48cad42d1c1999da21cfa221cfa037aa44b81ad91d4a8d1d581540cf6c39176eeab2770f00b461d43fa328ae650837e79c9e8f6c417951dc2e4d32634de493b88e0d167016e2646590e686571dcf2104af43ab137d` (160B)
* `cargo test --release` — **67/67 green**, `oracle_celt 3/3`.
* Silence transition (48 kHz stereo / 192 kbps VBR test): C-faithful `dc_reject` residue decays at ~`0.685/frame` (coef2^960); verified against C 1.6, with packets remaining ~481 B through zero frame 30 and shrinking to 3 B at frame 31. `celt_silence_regression` updated to that expectation.
* Interop: per-frame SNR @128k stereo complex — C 31dB / Rust 21-28dB at the C-faithful 624-sample delay (`240 CELT + 192 ring + compensation`). Alignment search window widened from `0..500` to `0..700` to include the now C-faithful 624-sample encoder delay.

## Remaining gap (documented, out of scope)

* Impulse oracle `f87346b9...5858` vs C `f87346b9...8965` diverges at byte 7 — missing `analysis.c` tonality (`tonality_slope → alloc_trim` C:1 vs Rust:0, and `max_pitch_ratio`). This gap is outside this PR's acceptance criterion: the primary sine oracle is byte-exact, while the impulse case is deterministic and remains decoder-stable. Full tonality-analysis parity is tracked as a separate milestone.

## Compatibility

* `#![no_std]` + `no-alloc` preserved (`FixedVec`, heap-feature `Box` for large buffers).
* `upstream/bcd09b3` (`core::cmp`, version `0.1.31`) merged via `314915f`.

## Checklist

* [x] `cargo test --release` 67/67 green
* [x] `cargo test --test oracle_celt --release` primary sine oracle byte-exact
* [x] No encoder/debug instrumentation left in production code; test diagnostics only
* [x] Branch `pr/celt-byte-exact-1.6` pushed to `origin`
