### PR TITLE
fix(celt): correct haar1 AVX deinterleave, VBR nominal cap, and VBR-fragile tests

### DIFF
--- a/src/bands.rs
+++ b/src/bands.rs
@@ -209,8 +209,13 @@ pub fn haar1(x: &mut [f32], n0: usize, stride: usize) {
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     unsafe {
-        if stride == 1 && n0 >= 16 && crate::compat::x86_has_avx() {
-            haar1_avx(x, n0);
+        // NOTE: the previous AVX1 kernel loaded its second vector at +4
+        // (overlapping the first) and deinterleaved into quartet-swapped
+        // order, corrupting every other 8-sample block. The corrected kernel
+        // needs a 64-bit lane permute, which is AVX2-only; pre-AVX2 CPUs use
+        // the scalar path.
+        if stride == 1 && n0 >= 16 && crate::compat::x86_has_avx2() {
+            haar1_avx2(x, n0);
             return;
         }
     }
@@ -219,25 +224,28 @@ pub fn haar1(x: &mut [f32], n0: usize, stride: usize) {
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[target_feature(enable = "avx")]
-unsafe fn haar1_avx(x: &mut [f32], n0: usize) {
+#[target_feature(enable = "avx2")]
+unsafe fn haar1_avx2(x: &mut [f32], n0: usize) {
     #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
     #[cfg(target_arch = "x86")]
     use core::arch::x86::*;
     let n = n0 >> 1;
     let scale = _mm256_set1_ps(core::f32::consts::FRAC_1_SQRT_2);
+    let fixup = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
     let mut j = 0;
     while j + 8 <= n {
         let ptr = x.as_mut_ptr().add(2 * j);
         let a = _mm256_loadu_ps(ptr);
-        let b = _mm256_loadu_ps(ptr.add(4));
+        let b = _mm256_loadu_ps(ptr.add(8));
 
         let t0 = _mm256_unpacklo_ps(a, b);
         let t1 = _mm256_unpackhi_ps(a, b);
 
-        let even = _mm256_unpacklo_ps(t0, t1);
-        let odd = _mm256_unpackhi_ps(t0, t1);
+        // unpacklo/hi leave the two middle quartets swapped; fix the 32-bit
+        // lane order so even/odd hold pairs 0-7 in order.
+        let even = _mm256_permutevar8x32_ps(_mm256_unpacklo_ps(t0, t1), fixup);
+        let odd = _mm256_permutevar8x32_ps(_mm256_unpackhi_ps(t0, t1), fixup);
 
         let sum = _mm256_mul_ps(_mm256_add_ps(even, odd), scale);
         let diff = _mm256_mul_ps(_mm256_sub_ps(even, odd), scale);

--- a/src/bands.rs
+++ b/src/bands.rs
@@ -221,7 +221,10 @@ pub fn haar1(x: &mut [f32], n0: usize, stride: usize) {
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx")]
 unsafe fn haar1_avx(x: &mut [f32], n0: usize) {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
     let n = n0 >> 1;
     let scale = _mm256_set1_ps(core::f32::consts::FRAC_1_SQRT_2);
     let mut j = 0;
@@ -1849,7 +1852,10 @@ fn prepare_lowband_views(
 #[target_feature(enable = "avx2")]
 #[allow(dead_code)]
 unsafe fn stereo_merge_avx2(x: &mut [f32], y: &mut [f32], mid: f32, side: f32, n: usize) {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
 
     let mut i = 0;
 
@@ -2513,7 +2519,10 @@ fn compute_band_energy_neon(band: &[f32]) -> f32 {
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2,fma")]
 unsafe fn compute_band_energy_avx2(band: &[f32]) -> f32 {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
 
     let n = band.len();
     let mut i = 0usize;
@@ -2660,7 +2669,10 @@ pub fn normalise_bands(
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 unsafe fn scale_slice_avx2(src: &[f32], dst: &mut [f32], scale: f32, n: usize) {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
     let vscale = _mm256_set1_ps(scale);
     let mut i = 0;
 
@@ -2843,7 +2855,10 @@ unsafe fn renormalise_vector_neon(x: &mut [f32], n: usize, gain: f32) {
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2,fma")]
 unsafe fn renormalise_vector_avx2(x: &mut [f32], n: usize, gain: f32) {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
 
     let mut i = 0usize;
 

--- a/src/celt.rs
+++ b/src/celt.rs
@@ -418,7 +418,10 @@ fn l1_metric(tmp: &[f32], n: usize, lm: i32, bias: f32) -> f32 {
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx")]
 unsafe fn sum_abs_avx(x: &[f32], n: usize) -> f32 {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
 
     let mut sum0 = _mm256_setzero_ps();
     let mut sum1 = _mm256_setzero_ps();
@@ -969,7 +972,10 @@ unsafe fn comb_filter_const_sse(
     g11: f32,
     g12: f32,
 ) {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
 
     let g10v = _mm_set1_ps(g10);
     let g11v = _mm_set1_ps(g11);
@@ -1035,7 +1041,10 @@ unsafe fn comb_filter_const_avx(
     g11: f32,
     g12: f32,
 ) {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
 
     let g10v = _mm256_set1_ps(g10);
     let g11v = _mm256_set1_ps(g11);
@@ -1138,7 +1147,10 @@ unsafe fn comb_filter_const_sse_fma(
     g11: f32,
     g12: f32,
 ) {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
 
     let g10v = _mm_set1_ps(g10);
     let g11v = _mm_set1_ps(g11);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -559,12 +559,18 @@ impl OpusEncoder {
         let cbr_bytes = ((target_bits + 4) / 8) as usize;
         let max_data_bytes = output.len();
 
-        // Cap at the Opus per-packet maximum (RFC 6716); the range coder's buffer
-        // is heap-free and sized to this constant.
-        let mut n_bytes = cbr_bytes
-            .min(max_data_bytes)
-            .max(1)
-            .min(OPUS_MAX_PACKET_BYTES);
+        // C parity (opus_encoder.c): the nominal-size cap applies in CBR mode
+        // only. In VBR mode the CELT-internal bound (vbr_rate/reservoir) decides
+        // the per-frame size, allowing overshoot (borrowing) and undershoot.
+        // Capping VBR at nominal defeats the reservoir and starves complex frames.
+        let mut n_bytes = if self.use_cbr {
+            cbr_bytes
+                .min(max_data_bytes)
+                .max(1)
+                .min(OPUS_MAX_PACKET_BYTES)
+        } else {
+            max_data_bytes.max(1).min(OPUS_MAX_PACKET_BYTES)
+        };
         let init_rc_size = n_bytes - 1;
         self.rc.reset_for_encode(init_rc_size as u32);
 

--- a/src/mdct.rs
+++ b/src/mdct.rs
@@ -540,7 +540,10 @@ unsafe fn mdct_backward_post_rotation_avx(
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx")]
 unsafe fn mdct_tdac_avx(output: &mut [f32], window: &[f32], overlap: usize) {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
 
     let overlap2 = overlap / 2;
     let mut i = 0usize;

--- a/src/pitch.rs
+++ b/src/pitch.rs
@@ -304,7 +304,10 @@ unsafe fn pitch_xcorr_neon(x: &[f32], y: &[f32], xcorr: &mut [f32], len: usize, 
 #[inline(always)]
 #[allow(unsafe_op_in_unsafe_fn)]
 unsafe fn inner_prod_sse(x: &[f32], y: &[f32], n: usize) -> f32 {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
 
     let mut sum0 = _mm_setzero_ps();
     let mut sum1 = _mm_setzero_ps();
@@ -346,7 +349,10 @@ unsafe fn inner_prod_sse(x: &[f32], y: &[f32], n: usize) -> f32 {
 #[inline(always)]
 #[allow(unsafe_op_in_unsafe_fn)]
 unsafe fn dual_inner_prod_sse(x: &[f32], y1: &[f32], y2: &[f32], n: usize) -> (f32, f32) {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
 
     let mut xy1 = _mm_setzero_ps();
     let mut xy2 = _mm_setzero_ps();
@@ -386,7 +392,10 @@ unsafe fn dual_inner_prod_sse(x: &[f32], y1: &[f32], y2: &[f32], n: usize) -> (f
 #[inline(always)]
 #[allow(unsafe_op_in_unsafe_fn)]
 unsafe fn xcorr_kernel_sse(x: &[f32], y: &[f32], sum: &mut [f32; 4], len: usize) {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
 
     let mut xsum1 = _mm_loadu_ps(sum.as_ptr());
     let mut xsum2 = _mm_setzero_ps();
@@ -472,7 +481,10 @@ unsafe fn pitch_xcorr_sse(x: &[f32], y: &[f32], xcorr: &mut [f32], len: usize, m
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx,fma")]
 unsafe fn inner_prod_avx(x: &[f32], y: &[f32], n: usize) -> f32 {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
 
     let mut acc0 = _mm256_setzero_ps();
     let mut acc1 = _mm256_setzero_ps();
@@ -516,7 +528,10 @@ unsafe fn inner_prod_avx(x: &[f32], y: &[f32], n: usize) -> f32 {
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx,fma")]
 unsafe fn dual_inner_prod_avx(x: &[f32], y1: &[f32], y2: &[f32], n: usize) -> (f32, f32) {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
 
     let mut acc1 = _mm256_setzero_ps();
     let mut acc2 = _mm256_setzero_ps();
@@ -598,7 +613,10 @@ unsafe fn pitch_xcorr_avx(x: &[f32], y: &[f32], xcorr: &mut [f32], len: usize, m
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx,fma")]
 unsafe fn xcorr_kernel_avx(x: &[f32], y: &[f32], sum: &mut [f32; 4], len: usize) {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
 
     let mut xsum1 = _mm_loadu_ps(sum.as_ptr());
     let mut xsum2 = _mm_setzero_ps();
@@ -903,7 +921,10 @@ fn find_best_pitch(
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     let mut syy = unsafe {
         if crate::compat::x86_has_avx() {
+            #[cfg(target_arch = "x86_64")]
             use core::arch::x86_64::*;
+            #[cfg(target_arch = "x86")]
+            use core::arch::x86::*;
             let mut acc0 = _mm256_setzero_ps();
             let mut acc1 = _mm256_setzero_ps();
             let mut j = 0;

--- a/src/pvq.rs
+++ b/src/pvq.rs
@@ -536,7 +536,10 @@ fn pvq_search_n4(x: &[f32], y: &mut [i32], k: i32) {
 
     #[cfg(target_arch = "x86_64")]
     unsafe {
+        #[cfg(target_arch = "x86_64")]
         use core::arch::x86_64::*;
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::*;
 
         let sign_mask = _mm_castsi128_ps(_mm_set1_epi32(0x7FFF_FFFFu32 as i32));
         let vx = _mm_loadu_ps(x.as_ptr());
@@ -1646,7 +1649,10 @@ fn pvq_search_neon(x: &[f32], y: &mut [i32], k: i32, n: usize) {
 #[target_feature(enable = "avx2,fma")]
 #[allow(unsafe_op_in_unsafe_fn)]
 unsafe fn pvq_search_avx2(x: &[f32], y: &mut [i32], k: i32, n: usize) {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
 
     debug_assert!(n <= 31);
     debug_assert!(k > 4);
@@ -2017,7 +2023,10 @@ pub fn extract_collapse_mask(iy: &[i32], n: usize, b: usize) -> u32 {
 #[target_feature(enable = "avx2,fma")]
 #[allow(unsafe_op_in_unsafe_fn)]
 unsafe fn renormalise_vector_avx2(x: &mut [f32], n: usize, gain: f32) {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
 
     let mut acc0 = _mm256_setzero_ps();
     let mut acc1 = _mm256_setzero_ps();
@@ -2071,7 +2080,10 @@ unsafe fn renormalise_vector_avx2(x: &mut [f32], n: usize, gain: f32) {
 #[target_feature(enable = "avx2,fma")]
 #[allow(unsafe_op_in_unsafe_fn)]
 unsafe fn alg_quant_resynth_avx2(y: &[i32], x: &mut [f32], n: usize, gain: f32) {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
 
     let mut acc0 = _mm256_setzero_ps();
     let mut i = 0;
@@ -2120,7 +2132,10 @@ unsafe fn pvq_search_scalar_init_avx2(
     abs_x: &mut [f32; 32],
     sign_x: &mut [i32; 32],
 ) -> f32 {
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::*;
     let sign_mask = _mm256_set1_ps(-0.0f32);
     let mut acc = _mm256_setzero_ps();
     let mut i = 0;

--- a/tests/canary_mono.rs
+++ b/tests/canary_mono.rs
@@ -12,8 +12,10 @@ fn mono_impulse_48k_64k_finite_small_packet() {
     enc.bitrate_bps = br;
     let mut buf = vec![0u8; 1276];
     let n = enc.encode(&pcm, fs, &mut buf).unwrap();
+    // Reference: libopus (vcpkg 1.5.2) emits 282 bytes for this exact input,
+    // so the bound tracks C parity with margin rather than the nominal 240B.
     assert!(
-        n > 0 && n <= 200,
+        n > 0 && n <= 320,
         "packet huge {} bytes: {:02x?}",
         n,
         &buf[..n.min(8)]

--- a/tests/multi_frame_interop_test.rs
+++ b/tests/multi_frame_interop_test.rs
@@ -77,6 +77,9 @@ fn test_celt_multi_frame_code_0_and_1() {
 
     let mut enc = OpusEncoder::new(sr, ch, Application::RestrictedLowDelay).unwrap();
     enc.bitrate_bps = 64000;
+    // Code 1 requires equal-sized frames (RFC 6716 §3.2.1); VBR sizes vary
+    // legitimately, so pin CBR for deterministic equal payloads.
+    enc.use_cbr = true;
 
     let pcm0 = make_sine(440.0, sr, fs, ch, 0);
     let pcm1 = make_sine(440.0, sr, fs, ch, 1);
@@ -173,7 +176,9 @@ fn test_celt_multi_frame_code_3_with_padding() {
 
     let mut enc = OpusEncoder::new(sr, ch, Application::RestrictedLowDelay).unwrap();
     enc.bitrate_bps = 64000;
-
+    // Zero-padding payloads is only neutral when both already share a size;
+    // VBR sizes vary legitimately, so pin CBR to keep the resize a no-op.
+    enc.use_cbr = true;
     let pcm0 = make_sine(440.0, sr, fs, ch, 0);
     let pcm1 = make_sine(660.0, sr, fs, ch, 1);
     let pkt0 = encode_full(&mut enc, &pcm0, fs, 400);
@@ -301,9 +306,11 @@ fn test_hybrid_multi_frame_roundtrip() {
     let sr = 48000;
     let ch = 1;
     let fs = 960;
-
     let mut enc = OpusEncoder::new(sr, ch, Application::Audio).unwrap();
     enc.bitrate_bps = 64000;
+    // Code 1 requires equal-sized frames (RFC 6716 §3.2.1); VBR sizes vary
+    // legitimately, so pin CBR for deterministic equal payloads.
+    enc.use_cbr = true;
 
     let pcm0 = make_sine(440.0, sr, fs, ch, 0);
     let pcm1 = make_sine(660.0, sr, fs, ch, 1);
@@ -398,6 +405,9 @@ fn test_multi_frame_all_codes_stereo() {
 
     let mut enc = OpusEncoder::new(sr, ch, Application::Audio).unwrap();
     enc.bitrate_bps = 96000;
+    // Code 1 requires equal-sized frames (RFC 6716 §3.2.1); VBR sizes vary
+    // legitimately, so pin CBR for deterministic equal payloads.
+    enc.use_cbr = true;
 
     let pcm0 = make_sine(440.0, sr, fs, ch, 0);
     let pcm1 = make_sine(660.0, sr, fs, ch, 1);


### PR DESCRIPTION
Includes #16 as base commit; happy to rebase if #16 lands first.

## haar1 AVX deinterleave (the audibility fix)

`haar1_avx` loaded its second vector at +4 instead of +8 (overlapping the first) and deinterleaved into quartet-swapped order, corrupting every other 8-sample block of stride-1 Haar transforms with n0>=16. This poisoned tf_analysis best-level selection and recombine/time-divide paths, decorrelating everything above ~1kHz at the same bitrate (mono 96k shape corr vs source: 2-4kHz 0.87, 4-8kHz 0.80, 8-14kHz 0.81; libopus scores 0.99+).

Replaced with an AVX2 kernel (permutevar8x32 lane fixup); pre-AVX2 CPUs fall back to the scalar path, which was already correct (NEON uses vld2/vst2 and is unaffected). Verified bit-near-identical to libopus float haar1 (max abs diff 5.3e-8, 0/64 lanes differ). After the fix, mono 96k shapes read 0.99/0.98/0.99/0.98/0.97 and stereo 192k reads ~0.999 across bands.

Note vs #16: that PR only gates the imports of `haar1_avx`; this PR replaces the kernel body itself (and carries the same cfg-gated import pattern on the new function so 32-bit keeps compiling).

## VBR nominal cap

Packets were hard-capped at nominal size in VBR mode (libopus caps CBR only, opus_encoder.c), neutering the reservoir: C emits 265B where we emitted 240B on the same transient frame. The nominal cap now applies in CBR mode only. Average bitrate is unchanged; frames may now borrow above nominal like C does.

## Tests

- canary impulse bound tracks C parity (libopus emits 282B for the vector; the old 200B bound was tighter than C). Decode-side guard (finite, <15.0) untouched.
- 4 multi-frame interop tests pinned to CBR: RFC 6716 code 1 requires equal-sized frames and zero-padding payloads is only neutral at equal sizes, neither of which VBR guarantees.

## Verification (re-run after stacking onto #16)

- Full suite green, incl. byte-exact oracles (`oracle_celt_*` pass, so existing vectors are unaffected).
- i686 lib check clean (0 errors).
- `cargo fmt --check` reports 22 diffs, all inside #16's added lines under newer rustfmt (import ordering); none from this PR's hunks. Upstream has no fmt CI; left untouched to avoid noise against #16.
- Quality numbers decoded with libopus (ffmpeg); C-encoder differentials via vcpkg 1.5.2; audit baseline is the v1.6.1-series tree.
